### PR TITLE
Add a basic CI pipeline.

### DIFF
--- a/.github/workflows/cmake-single-platform.yml
+++ b/.github/workflows/cmake-single-platform.yml
@@ -1,0 +1,44 @@
+
+name: Compile PoseLib and Run Benchmark
+
+on:
+  pull_request:
+    branches:
+      - '**'
+
+env:
+  BUILD_TYPE: Release
+  BUILD_SHARED_LIBS: OFF # static
+  BUILD_DIR: _build
+  INSTALL_DIR: _install
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Install Eigen3
+      run: sudo apt-get update && sudo apt-get install -y libeigen3-dev
+
+    - name: Configure CMake
+      run: |      
+        cmake -B ${{github.workspace}}/${{env.BUILD_DIR}} \
+          -DWITH_BENCHMARK=ON \
+          -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} \
+          -DBUILD_SHARED_LIBS=${{env.BUILD_SHARED_LIBS}} \
+          -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/${{env.INSTALL_DIR}}
+
+    - name: Build
+      run: |     
+        cmake \
+          --build ${{github.workspace}}/${{env.BUILD_DIR}} \
+          --config ${{env.BUILD_TYPE}} \
+          --target install \
+          -j $(nproc)
+
+    - name: Test
+      working-directory: ${{github.workspace}}
+      run: ${{env.INSTALL_DIR}}/bin/benchmark
+    


### PR DESCRIPTION
This adds a basic continuous integration. It will compile the code and run the benchmark. Perhaps we want to separate running the benchmark as an optional step.