### PR TITLE
Disable -Warray-bounds for bundle.cc due to false positive on GCC>=12

### DIFF
--- a/PoseLib/robust/bundle.cc
+++ b/PoseLib/robust/bundle.cc
@@ -26,6 +26,10 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+#if __GNUC__ >= 12
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#endif
+
 #include "bundle.h"
 
 #include "PoseLib/robust/jacobian_impl.h"


### PR DESCRIPTION
Due to gcc>=12 raising false positive warning (turned into an error by -Werror) about accessing outside of array bounds (this issue is reported in [Eigen](https://gitlab.com/libeigen/eigen/-/issues/2506) and in [gcc](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=106247)), i suggest to suppress such diagnostic in file where it happening and for compilers that are currently affected.