### PR TITLE
Rename uninstall target to be more specific

### DIFF
--- a/cmake/SetEnv.cmake
+++ b/cmake/SetEnv.cmake
@@ -105,7 +105,7 @@ configure_package_config_file(
 configure_file("${PROJECT_SOURCE_DIR}/cmake/Uninstall.cmake.in"
   "${GENERATED_DIR}/Uninstall.cmake"
   IMMEDIATE @ONLY)
-add_custom_target(uninstall
+add_custom_target(uninstall_poselib
   COMMAND ${CMAKE_COMMAND} -P ${GENERATED_DIR}/Uninstall.cmake)
 
 # Always full RPATH (for shared libraries)


### PR DESCRIPTION
Renames the uninstall target so that it's easier to integrate into other projects.

See here https://github.com/colmap/colmap/pull/2288#discussion_r1413180196