### PR TITLE
Implementation of OpenCVFisheye camera model

### DIFF
--- a/PoseLib/misc/colmap_models.cc
+++ b/PoseLib/misc/colmap_models.cc
@@ -632,8 +632,9 @@ double opencv_fisheye_newton(const std::vector<double> &params, double rd, doubl
         if (std::abs(f) < UNDIST_TOL) {
             return std::abs(f);
         }
-        const double fp = (1.0 + 3.0 * theta2 * params[4] + 5.0 * theta4 * params[5] + 7.0 * theta6 * params[6] +
+        double fp = (1.0 + 3.0 * theta2 * params[4] + 5.0 * theta4 * params[5] + 7.0 * theta6 * params[6] +
                            9.0 * theta8 * params[7]);
+        fp += std::copysign(1e-10, fp);
         theta = theta - f / fp;
     }
     return std::abs(f);

--- a/PoseLib/misc/colmap_models.cc
+++ b/PoseLib/misc/colmap_models.cc
@@ -125,12 +125,11 @@ void Camera::unproject(const Eigen::Vector2d &xp, Eigen::Vector2d *x) const {
 #undef SWITCH_CAMERA_MODEL_CASE
 }
 
-
 void Camera::project(const std::vector<Eigen::Vector2d> &x, std::vector<Eigen::Vector2d> *xp) const {
     xp->resize(x.size());
 #define SWITCH_CAMERA_MODEL_CASE(Model)                                                                                \
     case Model::model_id:                                                                                              \
-        for (size_t i = 0; i < x.size(); ++i) {                                                                           \
+        for (size_t i = 0; i < x.size(); ++i) {                                                                        \
             Model::project(params, x[i], &((*xp)[i]));                                                                 \
         }                                                                                                              \
         break;
@@ -149,7 +148,7 @@ void Camera::project_with_jac(const std::vector<Eigen::Vector2d> &x, std::vector
     jac->resize(x.size());
 #define SWITCH_CAMERA_MODEL_CASE(Model)                                                                                \
     case Model::model_id:                                                                                              \
-        for (size_t i = 0; i < x.size(); ++i) {                                                                           \
+        for (size_t i = 0; i < x.size(); ++i) {                                                                        \
             Model::project_with_jac(params, x[i], &((*xp)[i]), &((*jac)[i]));                                          \
         }                                                                                                              \
         break;
@@ -167,7 +166,7 @@ void Camera::unproject(const std::vector<Eigen::Vector2d> &xp, std::vector<Eigen
     x->resize(xp.size());
 #define SWITCH_CAMERA_MODEL_CASE(Model)                                                                                \
     case Model::model_id:                                                                                              \
-        for (size_t i = 0; i < xp.size(); ++i) {                                                                          \
+        for (size_t i = 0; i < xp.size(); ++i) {                                                                       \
             Model::unproject(params, xp[i], &((*x)[i]));                                                               \
         }                                                                                                              \
         break;
@@ -573,7 +572,8 @@ void OpenCVFisheyeCameraModel::project(const std::vector<double> &params, const 
         // Very close to the principal axis - ignore distortion
         (*xp)(0) = params[0] * x(0) + params[2];
         (*xp)(1) = params[1] * x(1) + params[3];
-    }}
+    }
+}
 void OpenCVFisheyeCameraModel::project_with_jac(const std::vector<double> &params, const Eigen::Vector2d &x,
                                                 Eigen::Vector2d *xp, Eigen::Matrix2d *jac) {
     double rho = x.norm();
@@ -593,7 +593,7 @@ void OpenCVFisheyeCameraModel::project_with_jac(const std::vector<double> &param
 
         double rho_z2 = rho * rho + 1.0;
         double dtheta_drho = 1.0 / rho_z2;
-        
+
         double drd_dtheta = (1.0 + 3.0 * theta2 * params[4] + 5.0 * theta4 * params[5] + 7.0 * theta6 * params[6] +
                              9.0 * theta8 * params[7]);
         double drd_dx = drd_dtheta * dtheta_drho * drho_dx;
@@ -621,7 +621,6 @@ void OpenCVFisheyeCameraModel::project_with_jac(const std::vector<double> &param
     }
 }
 
-
 double opencv_fisheye_newton(const std::vector<double> &params, double rd, double &theta) {
     double f;
     for (size_t iter = 0; iter < UNDIST_MAX_ITER; iter++) {
@@ -639,7 +638,6 @@ double opencv_fisheye_newton(const std::vector<double> &params, double rd, doubl
     }
     return std::abs(f);
 }
-
 
 void OpenCVFisheyeCameraModel::unproject(const std::vector<double> &params, const Eigen::Vector2d &xp,
                                          Eigen::Vector2d *x) {

--- a/PoseLib/misc/colmap_models.cc
+++ b/PoseLib/misc/colmap_models.cc
@@ -633,7 +633,7 @@ double opencv_fisheye_newton(const std::vector<double> &params, double rd, doubl
             return std::abs(f);
         }
         double fp = (1.0 + 3.0 * theta2 * params[4] + 5.0 * theta4 * params[5] + 7.0 * theta6 * params[6] +
-                           9.0 * theta8 * params[7]);
+                     9.0 * theta8 * params[7]);
         fp += std::copysign(1e-10, fp);
         theta = theta - f / fp;
     }

--- a/PoseLib/misc/colmap_models.h
+++ b/PoseLib/misc/colmap_models.h
@@ -48,6 +48,12 @@ struct Camera {
     void project_with_jac(const Eigen::Vector2d &x, Eigen::Vector2d *xp, Eigen::Matrix2d *jac) const;
     void unproject(const Eigen::Vector2d &xp, Eigen::Vector2d *x) const;
 
+    // vector wrappers for the project/unprojection
+    void project(const std::vector<Eigen::Vector2d> &x, std::vector<Eigen::Vector2d> *xp) const;
+    void project_with_jac(const std::vector<Eigen::Vector2d> &x, std::vector<Eigen::Vector2d> *xp,
+                          std::vector<Eigen::Matrix<double, 2, 2>> *jac) const;
+    void unproject(const std::vector<Eigen::Vector2d> &xp, std::vector<Eigen::Vector2d> *x) const;
+
     // Update the camera parameters such that the projections are rescaled
     void rescale(double scale);
     // Return camera model as string
@@ -88,7 +94,7 @@ SETUP_CAMERA_SHARED_DEFS(PinholeCameraModel, "PINHOLE", 1);
 SETUP_CAMERA_SHARED_DEFS(SimpleRadialCameraModel, "SIMPLE_RADIAL", 2);
 SETUP_CAMERA_SHARED_DEFS(RadialCameraModel, "RADIAL", 3);
 SETUP_CAMERA_SHARED_DEFS(OpenCVCameraModel, "OPENCV", 4);
-SETUP_CAMERA_SHARED_DEFS(OpenCVFisheyeCameraModel, "OPENCV_FISHEYE", 8);
+SETUP_CAMERA_SHARED_DEFS(OpenCVFisheyeCameraModel, "OPENCV_FISHEYE", 5);
 
 #define SWITCH_CAMERA_MODELS                                                                                           \
     SWITCH_CAMERA_MODEL_CASE(NullCameraModel)                                                                          \

--- a/benchmark/benchmark.cc
+++ b/benchmark/benchmark.cc
@@ -258,8 +258,7 @@ void display_result(const std::vector<poselib::BenchmarkResult> &results) {
     std::cout << std::setw(w) << "Solutions";
     std::cout << std::setw(w) << "Valid";
     std::cout << std::setw(w) << "GT found";
-    std::cout << std::setw(w) << "Runtime"
-              << "\n";
+    std::cout << std::setw(w) << "Runtime" << "\n";
     for (int i = 0; i < w * 6; ++i)
         std::cout << "-";
     std::cout << "\n";

--- a/benchmark/benchmark.cc
+++ b/benchmark/benchmark.cc
@@ -258,7 +258,8 @@ void display_result(const std::vector<poselib::BenchmarkResult> &results) {
     std::cout << std::setw(w) << "Solutions";
     std::cout << std::setw(w) << "Valid";
     std::cout << std::setw(w) << "GT found";
-    std::cout << std::setw(w) << "Runtime" << "\n";
+    std::cout << std::setw(w) << "Runtime"
+              << "\n";
     for (int i = 0; i < w * 6; ++i)
         std::cout << "-";
     std::cout << "\n";

--- a/pybind/pyposelib.cc
+++ b/pybind/pyposelib.cc
@@ -789,13 +789,35 @@ PYBIND11_MODULE(poselib, m) {
 
     py::class_<poselib::Camera>(m, "Camera")
         .def(py::init<>())
+        .def_readwrite("model_id", &poselib::Camera::model_id)
+        .def_readwrite("width", &poselib::Camera::width)
+        .def_readwrite("height", &poselib::Camera::height)
         .def_readwrite("params", &poselib::Camera::params)
         .def("focal", &poselib::Camera::focal, "Returns the camera focal length.")
         .def("focal_x", &poselib::Camera::focal_x, "Returns the camera focal_x.")
         .def("focal_y", &poselib::Camera::focal_y, "Returns the camera focal_y.")
         .def("model_name", &poselib::Camera::model_name, "Returns the camera model name.")
         .def("prinicipal_point", &poselib::Camera::principal_point, "Returns the camera principal point.")
+        .def("initialize_from_txt", &poselib::Camera::initialize_from_txt, "Initialize camera from a cameras.txt line")
+        .def("project", [](poselib::Camera &self, std::vector<Eigen::Vector2d> &xp) {
+            std::vector<Eigen::Vector2d> x;
+            self.project(xp, &x);
+            return x;
+        })
+        .def("project_with_jac", [](poselib::Camera &self, std::vector<Eigen::Vector2d> &xp) {
+            std::vector<Eigen::Vector2d> x;
+            std::vector<Eigen::Matrix2d> jac;
+            self.project_with_jac(xp, &x, &jac);
+            return std::make_pair(x, jac);
+        })
+        .def("unproject", [](poselib::Camera &self, std::vector<Eigen::Vector2d> &x) {
+            std::vector<Eigen::Vector2d> xp;
+            self.unproject(x, &xp);
+            return xp;
+        })
         .def("__repr__", [](const poselib::Camera &a) { return a.to_cameras_txt(); });
+
+
 
     py::class_<poselib::Image>(m, "Image")
         .def(py::init<>())

--- a/pybind/pyposelib.cc
+++ b/pybind/pyposelib.cc
@@ -799,25 +799,26 @@ PYBIND11_MODULE(poselib, m) {
         .def("model_name", &poselib::Camera::model_name, "Returns the camera model name.")
         .def("prinicipal_point", &poselib::Camera::principal_point, "Returns the camera principal point.")
         .def("initialize_from_txt", &poselib::Camera::initialize_from_txt, "Initialize camera from a cameras.txt line")
-        .def("project", [](poselib::Camera &self, std::vector<Eigen::Vector2d> &xp) {
-            std::vector<Eigen::Vector2d> x;
-            self.project(xp, &x);
-            return x;
-        })
-        .def("project_with_jac", [](poselib::Camera &self, std::vector<Eigen::Vector2d> &xp) {
-            std::vector<Eigen::Vector2d> x;
-            std::vector<Eigen::Matrix2d> jac;
-            self.project_with_jac(xp, &x, &jac);
-            return std::make_pair(x, jac);
-        })
-        .def("unproject", [](poselib::Camera &self, std::vector<Eigen::Vector2d> &x) {
-            std::vector<Eigen::Vector2d> xp;
-            self.unproject(x, &xp);
-            return xp;
-        })
+        .def("project",
+             [](poselib::Camera &self, std::vector<Eigen::Vector2d> &xp) {
+                 std::vector<Eigen::Vector2d> x;
+                 self.project(xp, &x);
+                 return x;
+             })
+        .def("project_with_jac",
+             [](poselib::Camera &self, std::vector<Eigen::Vector2d> &xp) {
+                 std::vector<Eigen::Vector2d> x;
+                 std::vector<Eigen::Matrix2d> jac;
+                 self.project_with_jac(xp, &x, &jac);
+                 return std::make_pair(x, jac);
+             })
+        .def("unproject",
+             [](poselib::Camera &self, std::vector<Eigen::Vector2d> &x) {
+                 std::vector<Eigen::Vector2d> xp;
+                 self.unproject(x, &xp);
+                 return xp;
+             })
         .def("__repr__", [](const poselib::Camera &a) { return a.to_cameras_txt(); });
-
-
 
     py::class_<poselib::Image>(m, "Image")
         .def(py::init<>())

--- a/scripts/clang_format.sh
+++ b/scripts/clang_format.sh
@@ -10,5 +10,6 @@ ROOT="$(readlink -f ${SCRIPT_ABS_PATH}/..)"
 
 find ${ROOT}/PoseLib -iname "*.h" -o -iname "*.cc" | xargs clang-format -i --verbose
 find ${ROOT}/benchmark -iname "*.h" -o -iname "*.cc" | xargs clang-format -i --verbose
+clang-format -i --verbose ${ROOT}/pybind/pyposelib.cc
 
 echo $(clang-format --version)


### PR DESCRIPTION
Add implementation of OpenCVFisheye camera model, as noted here https://github.com/colmap/glomap/issues/17#issuecomment-2265765607

Test consistency with pycolmap on randomly selected points for a couple of different cameras. The implementation is currently broken for wide FOV cameras (>180 degree) however. This will be addressed in https://github.com/PoseLib/PoseLib/tree/camera_models in the future.