### PR TITLE
Add Conan install section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,21 @@ Uninstall library:
 
     > make uninstall
 
+## Installation
+
+### Installing PoseLib using Conan
+
+You can install pre-built binaries for PoseLib or build it from source using
+[Conan](https://conan.io/). Use the following command:
+
+```bash
+conan install --requires="poselib/[*]" --build=missing
+```
+
+The PoseLib Conan recipe is kept up to date by Conan maintainers and community
+contributors. If the version is out of date, please
+[create an issue or pull request](https://github.com/conan-io/conan-center-index)
+on the ConanCenterIndex repository.
 
 ## Benchmark
 


### PR DESCRIPTION
Hello!

As asked in the comment https://github.com/PoseLib/PoseLib/issues/103#issuecomment-2269887578, this PR brings the steps of installation for PoseLib, when using Conan.

I did not add how to install/configure Conan, because the embedded links has the content already, and it will avoid polluting the README file.

Currently, the version 2.0.3 is the latest available in Conan Center: https://conan.io/center/recipes/poselib?version=2.0.3

I'll open a new PR to bump to 2.0.4 asap.

The command `conan install --requires="poselib/[*]" --build=missing` means:

- conan install: Install a package from a remote. By default, it points to the official Conan Center
- --requires="poselib/[*]": Install the latest version of poselib available
- --build=missing:  In not finding a pre-built package compatible, build it from source then.

Regards! 

