### PR TITLE
Fix dev branch 6pt shared focal refinement

### DIFF
--- a/PoseLib/robust/bundle.cc
+++ b/PoseLib/robust/bundle.cc
@@ -233,20 +233,17 @@ BundleStats refine_relpose(const std::vector<Point2D> &x1, const std::vector<Poi
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////
-// Relative pose (essential matrix) refinement
+// Relative pose with unknown shared focal refinement
 
 template <typename WeightType>
 BundleStats refine_shared_focal_relpose(const std::vector<Point2D> &x1, const std::vector<Point2D> &x2,
                                         ImagePair *image_pair, const BundleOptions &opt, const WeightType &weights) {
-    // LossFunction loss_fn(opt.loss_scale);
-    // IterationCallback callback = setup_callback(opt, loss_fn);
-    // SharedFocalRelativePoseJacobianAccumulator<LossFunction, WeightType> accum(x1, x2, loss_fn, weights);
-    // return lm_impl<decltype(accum)>(accum, image_pair, opt, callback);
-    throw std::runtime_error("TODO FIX SharedFocalRelativePoseJacobianAccumulator");
-    return BundleStats(); // TODO
+    IterationCallback callback = setup_callback(opt);
+    SharedFocalRelativePoseRefiner<decltype(weights)> refiner(x1, x2, weights);
+    return lm_impl<decltype(refiner)>(refiner, image_pair, opt, callback);
 }
 
-// Entry point for essential matrix refinement
+// Entry point for relative pose with unknown shared focal refinement
 BundleStats refine_shared_focal_relpose(const std::vector<Point2D> &x1, const std::vector<Point2D> &x2,
                                         ImagePair *image_pair, const BundleOptions &opt,
                                         const std::vector<double> &weights) {

--- a/PoseLib/robust/estimators/relative_pose.cc
+++ b/PoseLib/robust/estimators/relative_pose.cc
@@ -90,9 +90,7 @@ void SharedFocalRelativePoseEstimator::generate_models(ImagePairVector *models) 
 }
 
 double SharedFocalRelativePoseEstimator::score_model(const ImagePair &image_pair, size_t *inlier_count) const {
-    Eigen::Matrix3d K_inv;
-    K_inv << 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, image_pair.camera1.focal();
-    // K_inv << 1.0 / calib_pose.camera.focal(), 0.0, 0.0, 0.0, 1.0 / calib_pose.camera.focal(), 0.0, 0.0, 0.0, 1.0;
+    Eigen::DiagonalMatrix<double, 3> K_inv(1.0, 1.0, image_pair.camera1.focal());
     Eigen::Matrix3d E;
     essential_from_motion(image_pair.pose, &E);
     Eigen::Matrix3d F = K_inv * (E * K_inv);
@@ -106,9 +104,7 @@ void SharedFocalRelativePoseEstimator::refine_model(ImagePair *image_pair) const
     bundle_opt.loss_scale = opt.max_epipolar_error;
     bundle_opt.max_iterations = 25;
 
-    Eigen::Matrix3d K_inv;
-    // K_inv << 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, calib_pose->camera.focal();
-    K_inv << 1.0 / image_pair->camera1.focal(), 0.0, 0.0, 0.0, 1.0 / image_pair->camera1.focal(), 0.0, 0.0, 0.0, 1.0;
+    Eigen::DiagonalMatrix<double, 3> K_inv(1.0, 1.0, image_pair->camera1.focal());
     Eigen::Matrix3d E;
     essential_from_motion(image_pair->pose, &E);
     Eigen::Matrix3d F = K_inv * (E * K_inv);

--- a/PoseLib/robust/optim/relative.h
+++ b/PoseLib/robust/optim/relative.h
@@ -161,7 +161,7 @@ class PinholeRelativePoseRefiner : public RefinerBase<CameraPose, Accumulator> {
     Eigen::Matrix<double, 3, 2> tangent_basis;
 };
 
-// Minimize Sampson error with pinhole camera model. Assumes image points are in the normalized image plane.
+// Minimize Sampson error with pinhole camera model for relative pose and one unknown focal length shared by both cameras. 
 template <typename ResidualWeightVector = UniformWeightVector, typename Accumulator = NormalAccumulator>
 class SharedFocalRelativePoseRefiner : public RefinerBase<ImagePair, Accumulator> {
   public:

--- a/PoseLib/robust/optim/relative.h
+++ b/PoseLib/robust/optim/relative.h
@@ -161,6 +161,132 @@ class PinholeRelativePoseRefiner : public RefinerBase<CameraPose, Accumulator> {
     Eigen::Matrix<double, 3, 2> tangent_basis;
 };
 
+// Minimize Sampson error with pinhole camera model. Assumes image points are in the normalized image plane.
+template <typename ResidualWeightVector = UniformWeightVector, typename Accumulator = NormalAccumulator>
+class SharedFocalRelativePoseRefiner : public RefinerBase<ImagePair, Accumulator> {
+  public:
+    SharedFocalRelativePoseRefiner(const std::vector<Point2D> &points2D_1, const std::vector<Point2D> &points2D_2,
+                               const ResidualWeightVector &w = ResidualWeightVector())
+        : x1(points2D_1), x2(points2D_2), weights(w) {
+        this->num_params = 6;
+    }
+
+    double compute_residual(Accumulator &acc, const ImagePair &image_pair) {
+        Eigen::Matrix3d E, F;
+        essential_from_motion(image_pair.pose, &E);
+        Eigen::DiagonalMatrix<double, 3> K_inv(1.0, 1.0, image_pair.camera1.focal());
+        F = K_inv * E * K_inv;
+
+        for (size_t k = 0; k < x1.size(); ++k) {
+            double C = x2[k].homogeneous().dot(F * x1[k].homogeneous());
+            double nJc_sq = (F.block<2, 3>(0, 0) * x1[k].homogeneous()).squaredNorm() +
+                            (F.block<3, 2>(0, 0).transpose() * x2[k].homogeneous()).squaredNorm();
+
+            acc.add_residual(C / std::sqrt(nJc_sq), weights[k]);
+        }
+        return acc.get_residual();
+    }
+
+    void compute_jacobian(Accumulator &acc, const ImagePair &image_pair) {
+        // We start by setting up a basis for the updates in the translation (orthogonal to t)
+        // We find the minimum element of t and cross product with the corresponding basis vector.
+        // (this ensures that the first cross product is not close to the zero vector)
+        if (std::abs(image_pair.pose.t.x()) < std::abs(image_pair.pose.t.y())) {
+            // x < y
+            if (std::abs(image_pair.pose.t.x()) < std::abs(image_pair.pose.t.z())) {
+                tangent_basis.col(0) = image_pair.pose.t.cross(Eigen::Vector3d::UnitX()).normalized();
+            } else {
+                tangent_basis.col(0) = image_pair.pose.t.cross(Eigen::Vector3d::UnitZ()).normalized();
+            }
+        } else {
+            // x > y
+            if (std::abs(image_pair.pose.t.y()) < std::abs(image_pair.pose.t.z())) {
+                tangent_basis.col(0) = image_pair.pose.t.cross(Eigen::Vector3d::UnitY()).normalized();
+            } else {
+                tangent_basis.col(0) = image_pair.pose.t.cross(Eigen::Vector3d::UnitZ()).normalized();
+            }
+        }
+        tangent_basis.col(1) = tangent_basis.col(0).cross(image_pair.pose.t).normalized();
+
+        Eigen::Matrix3d E, F, R;
+        R = image_pair.pose.R();
+        essential_from_motion(image_pair.pose, &E);
+        double focal = image_pair.camera1.focal();
+        Eigen::DiagonalMatrix<double, 3> K_inv(1.0, 1.0, focal);
+        F = K_inv * E * K_inv;
+
+        // Matrices contain the jacobians of E w.r.t. the rotation and translation parameters
+        Eigen::Matrix<double, 9, 3> dR;
+        Eigen::Matrix<double, 9, 2> dt;
+        deriv_essential_wrt_pose(E, R, tangent_basis, dR, dt);
+
+        dR.row(2) *= focal;
+        dR.row(5) *= focal;
+        dR.row(6) *= focal;
+        dR.row(7) *= focal;
+        dR.row(8) *= focal * focal;
+
+        dt.row(2) *= focal;
+        dt.row(5) *= focal;
+        dt.row(6) *= focal;
+        dt.row(7) *= focal;
+        dt.row(8) *= focal * focal;
+
+        Eigen::Matrix<double, 9, 1> df;
+        df << 0.0, 0.0, E(2, 0), 0.0, 0.0, E(2, 1), E(0, 2), E(1, 2), 2 * E(2, 2) * focal;
+
+        for (size_t k = 0; k < x1.size(); ++k) {
+            double C = x2[k].homogeneous().dot(F * x1[k].homogeneous());
+
+            // J_C is the Jacobian of the epipolar constraint w.r.t. the image points
+            Eigen::Vector4d J_C;
+            J_C << F.block<3, 2>(0, 0).transpose() * x2[k].homogeneous(), F.block<2, 3>(0, 0) * x1[k].homogeneous();
+            const double nJ_C = J_C.norm();
+            const double inv_nJ_C = 1.0 / nJ_C;
+            const double r = C * inv_nJ_C;
+
+            // Compute Jacobian of Sampson error w.r.t the fundamental/essential matrix (3x3)
+            Eigen::Matrix<double, 1, 9> dF;
+            dF << x1[k](0) * x2[k](0), x1[k](0) * x2[k](1), x1[k](0), x1[k](1) * x2[k](0), x1[k](1) * x2[k](1),
+                x1[k](1), x2[k](0), x2[k](1), 1.0;
+            const double s = C * inv_nJ_C * inv_nJ_C;
+            dF(0) -= s * (J_C(2) * x1[k](0) + J_C(0) * x2[k](0));
+            dF(1) -= s * (J_C(3) * x1[k](0) + J_C(0) * x2[k](1));
+            dF(2) -= s * (J_C(0));
+            dF(3) -= s * (J_C(2) * x1[k](1) + J_C(1) * x2[k](0));
+            dF(4) -= s * (J_C(3) * x1[k](1) + J_C(1) * x2[k](1));
+            dF(5) -= s * (J_C(1));
+            dF(6) -= s * (J_C(2));
+            dF(7) -= s * (J_C(3));
+            dF *= inv_nJ_C;
+
+            // and then w.r.t. the pose parameters (rotation + tangent basis for translation)
+            Eigen::Matrix<double, 1, 6> J;
+            J.block<1, 3>(0, 0) = dF * dR;
+            J.block<1, 2>(0, 3) = dF * dt;
+            J(5) = dF * df;
+
+            acc.add_jacobian(r, J, weights[k]);
+        }
+    }
+
+    ImagePair step(const Eigen::VectorXd &dp, const ImagePair &image_pair) const {
+        CameraPose new_pose;
+        new_pose.q = quat_step_post(image_pair.pose.q, dp.block<3, 1>(0, 0));
+        new_pose.t = image_pair.pose.t + tangent_basis * dp.block<2, 1>(3, 0);
+
+        Camera new_camera = Camera("SIMPLE_PINHOLE", {image_pair.camera1.focal() + dp(5), 0, 0}, -1, -1);
+
+        return ImagePair(new_pose, new_camera, new_camera);
+    }
+
+    typedef ImagePair param_t;
+    const std::vector<Point2D> &x1;
+    const std::vector<Point2D> &x2;
+    const ResidualWeightVector &weights;
+    Eigen::Matrix<double, 3, 2> tangent_basis;
+};
+
 } // namespace poselib
 
 #endif


### PR DESCRIPTION
* Fix refinement for 6pt shared focal relative pose to new structure.
* Added tests.
* DiagonalMatrix<double, 3> for inverse of K instead of full matrix in `relative_pose.cc`.

Posebench results:
```
Dataset: scannet1500_sift
6pt pose + shared f (poselib): AUC5= 8.06, AUC10=18.38, AUC20=31.22, f AUC5=14.75, f AUC10=24.14, f AUC20=35.70, avg_rt= 19.0ms, med_rt= 21.9ms
Dataset: scannet1500_spsg
6pt pose + shared f (poselib): AUC5=10.78, AUC10=24.17, AUC20=41.49, f AUC5=13.19, f AUC10=23.76, f AUC20=37.28, avg_rt= 30.2ms, med_rt= 31.2ms
```
Slightly different from the current master, but seems ok.