### PR TITLE
Bugfix in default camera for shared focal relpose

### DIFF
--- a/PoseLib/robust/ransac.cc
+++ b/PoseLib/robust/ransac.cc
@@ -107,7 +107,7 @@ RansacStats ransac_shared_focal_relpose(const std::vector<Point2D> &x1, const st
     best_model->pose.q << 1.0, 0.0, 0.0, 0.0;
     best_model->pose.t.setZero();
     best_model->camera1 = Camera("SIMPLE_PINHOLE", std::vector<double>{1.0, 0.0, 0.0}, -1, -1);
-    best_model->camera2 = best_model->camera2;
+    best_model->camera2 = best_model->camera1;
     SharedFocalRelativePoseEstimator estimator(opt, x1, x2);
     RansacStats stats = ransac<SharedFocalRelativePoseEstimator>(estimator, opt, best_model);
 


### PR DESCRIPTION
Minor bug. May cause issues if RANSAC fails to find any model.