### PR TITLE
Release the GIL whenever possible to allow multithreading from python

### DIFF
--- a/pybind/pyposelib.cc
+++ b/pybind/pyposelib.cc
@@ -30,6 +30,7 @@ py::dict BundleOptions_wrapper(py::dict overwrite) {
 }
 
 std::vector<CameraPose> p3p_wrapper(const std::vector<Eigen::Vector3d> &x, const std::vector<Eigen::Vector3d> &X) {
+    py::gil_scoped_release release;
     std::vector<CameraPose> output;
     p3p(x, X, &output);
     return output;
@@ -37,6 +38,7 @@ std::vector<CameraPose> p3p_wrapper(const std::vector<Eigen::Vector3d> &x, const
 
 std::vector<CameraPose> gp3p_wrapper(const std::vector<Eigen::Vector3d> &p, const std::vector<Eigen::Vector3d> &x,
                                      const std::vector<Eigen::Vector3d> &X) {
+    py::gil_scoped_release release;
     std::vector<CameraPose> output;
     gp3p(p, x, X, &output);
     return output;
@@ -46,6 +48,7 @@ std::pair<std::vector<CameraPose>, std::vector<double>> gp4ps_wrapper(const std:
                                                                       const std::vector<Eigen::Vector3d> &x,
                                                                       const std::vector<Eigen::Vector3d> &X,
                                                                       bool filter_solutions = true) {
+    py::gil_scoped_release release;
     std::vector<CameraPose> output;
     std::vector<double> output_scales;
     gp4ps(p, x, X, &output, &output_scales, filter_solutions);
@@ -56,6 +59,7 @@ std::pair<std::vector<CameraPose>, std::vector<double>> gp4ps_kukelova_wrapper(c
                                                                                const std::vector<Eigen::Vector3d> &x,
                                                                                const std::vector<Eigen::Vector3d> &X,
                                                                                bool filter_solutions = true) {
+    py::gil_scoped_release release;
     std::vector<CameraPose> output;
     std::vector<double> output_scales;
     gp4ps_kukelova(p, x, X, &output, &output_scales, filter_solutions);
@@ -65,6 +69,7 @@ std::pair<std::vector<CameraPose>, std::vector<double>> gp4ps_kukelova_wrapper(c
 std::pair<std::vector<CameraPose>, std::vector<double>> gp4ps_camposeco_wrapper(const std::vector<Eigen::Vector3d> &p,
                                                                                 const std::vector<Eigen::Vector3d> &x,
                                                                                 const std::vector<Eigen::Vector3d> &X) {
+    py::gil_scoped_release release;
     std::vector<CameraPose> output;
     std::vector<double> output_scales;
     gp4ps_camposeco(p, x, X, &output, &output_scales);
@@ -74,6 +79,7 @@ std::pair<std::vector<CameraPose>, std::vector<double>> gp4ps_camposeco_wrapper(
 std::pair<std::vector<CameraPose>, std::vector<double>> p4pf_wrapper(const std::vector<Eigen::Vector2d> &x,
                                                                      const std::vector<Eigen::Vector3d> &X,
                                                                      bool filter_solutions = true) {
+    py::gil_scoped_release release;
     std::vector<CameraPose> output;
     std::vector<double> output_focal;
     p4pf(x, X, &output, &output_focal, filter_solutions);
@@ -83,12 +89,14 @@ std::pair<std::vector<CameraPose>, std::vector<double>> p4pf_wrapper(const std::
 std::vector<CameraPose> p2p2pl_wrapper(const std::vector<Eigen::Vector3d> &xp, const std::vector<Eigen::Vector3d> &Xp,
                                        const std::vector<Eigen::Vector3d> &x, const std::vector<Eigen::Vector3d> &X,
                                        const std::vector<Eigen::Vector3d> &V) {
+    py::gil_scoped_release release;
     std::vector<CameraPose> output;
     p2p2pl(xp, Xp, x, X, V, &output);
     return output;
 }
 
 std::vector<CameraPose> p6lp_wrapper(const std::vector<Eigen::Vector3d> &l, const std::vector<Eigen::Vector3d> &X) {
+    py::gil_scoped_release release;
     std::vector<CameraPose> output;
     p6lp(l, X, &output);
     return output;
@@ -96,6 +104,7 @@ std::vector<CameraPose> p6lp_wrapper(const std::vector<Eigen::Vector3d> &l, cons
 
 std::vector<CameraPose> p5lp_radial_wrapper(const std::vector<Eigen::Vector3d> &l,
                                             const std::vector<Eigen::Vector3d> &X) {
+    py::gil_scoped_release release;
     std::vector<CameraPose> output;
     p5lp_radial(l, X, &output);
     return output;
@@ -104,6 +113,7 @@ std::vector<CameraPose> p5lp_radial_wrapper(const std::vector<Eigen::Vector3d> &
 std::vector<CameraPose> p2p1ll_wrapper(const std::vector<Eigen::Vector3d> &xp, const std::vector<Eigen::Vector3d> &Xp,
                                        const std::vector<Eigen::Vector3d> &l, const std::vector<Eigen::Vector3d> &X,
                                        const std::vector<Eigen::Vector3d> &V) {
+    py::gil_scoped_release release;
     std::vector<CameraPose> output;
     p2p1ll(xp, Xp, l, X, V, &output);
     return output;
@@ -112,6 +122,7 @@ std::vector<CameraPose> p2p1ll_wrapper(const std::vector<Eigen::Vector3d> &xp, c
 std::vector<CameraPose> p1p2ll_wrapper(const std::vector<Eigen::Vector3d> &xp, const std::vector<Eigen::Vector3d> &Xp,
                                        const std::vector<Eigen::Vector3d> &l, const std::vector<Eigen::Vector3d> &X,
                                        const std::vector<Eigen::Vector3d> &V) {
+    py::gil_scoped_release release;
     std::vector<CameraPose> output;
     p1p2ll(xp, Xp, l, X, V, &output);
     return output;
@@ -119,12 +130,14 @@ std::vector<CameraPose> p1p2ll_wrapper(const std::vector<Eigen::Vector3d> &xp, c
 
 std::vector<CameraPose> p3ll_wrapper(const std::vector<Eigen::Vector3d> &l, const std::vector<Eigen::Vector3d> &X,
                                      const std::vector<Eigen::Vector3d> &V) {
+    py::gil_scoped_release release;
     std::vector<CameraPose> output;
     p3ll(l, X, V, &output);
     return output;
 }
 
 std::vector<CameraPose> up2p_wrapper(const std::vector<Eigen::Vector3d> &x, const std::vector<Eigen::Vector3d> &X) {
+    py::gil_scoped_release release;
     std::vector<CameraPose> output;
     up2p(x, X, &output);
     return output;
@@ -132,6 +145,7 @@ std::vector<CameraPose> up2p_wrapper(const std::vector<Eigen::Vector3d> &x, cons
 
 std::vector<CameraPose> ugp2p_wrapper(const std::vector<Eigen::Vector3d> &p, const std::vector<Eigen::Vector3d> &x,
                                       const std::vector<Eigen::Vector3d> &X) {
+    py::gil_scoped_release release;
     std::vector<CameraPose> output;
     ugp2p(p, x, X, &output);
     return output;
@@ -141,6 +155,7 @@ std::pair<std::vector<CameraPose>, std::vector<double>> ugp3ps_wrapper(const std
                                                                        const std::vector<Eigen::Vector3d> &x,
                                                                        const std::vector<Eigen::Vector3d> &X,
                                                                        bool filter_solutions = true) {
+    py::gil_scoped_release release;
     std::vector<CameraPose> output;
     std::vector<double> output_scales;
     ugp3ps(p, x, X, &output, &output_scales, filter_solutions);
@@ -150,6 +165,7 @@ std::pair<std::vector<CameraPose>, std::vector<double>> ugp3ps_wrapper(const std
 std::vector<CameraPose> up1p2pl_wrapper(const std::vector<Eigen::Vector3d> &xp, const std::vector<Eigen::Vector3d> &Xp,
                                         const std::vector<Eigen::Vector3d> &x, const std::vector<Eigen::Vector3d> &X,
                                         const std::vector<Eigen::Vector3d> &V) {
+    py::gil_scoped_release release;
     std::vector<CameraPose> output;
     up1p2pl(xp, Xp, x, X, V, &output);
     return output;
@@ -157,6 +173,7 @@ std::vector<CameraPose> up1p2pl_wrapper(const std::vector<Eigen::Vector3d> &xp, 
 
 std::vector<CameraPose> up4pl_wrapper(const std::vector<Eigen::Vector3d> &x, const std::vector<Eigen::Vector3d> &X,
                                       const std::vector<Eigen::Vector3d> &V) {
+    py::gil_scoped_release release;
     std::vector<CameraPose> output;
     up4pl(x, X, V, &output);
     return output;
@@ -164,6 +181,7 @@ std::vector<CameraPose> up4pl_wrapper(const std::vector<Eigen::Vector3d> &x, con
 
 std::vector<CameraPose> ugp4pl_wrapper(const std::vector<Eigen::Vector3d> &p, const std::vector<Eigen::Vector3d> &x,
                                        const std::vector<Eigen::Vector3d> &X, const std::vector<Eigen::Vector3d> &V) {
+    py::gil_scoped_release release;
     std::vector<CameraPose> output;
     ugp4pl(p, x, X, V, &output);
     return output;
@@ -171,18 +189,21 @@ std::vector<CameraPose> ugp4pl_wrapper(const std::vector<Eigen::Vector3d> &p, co
 
 std::vector<Eigen::Matrix3d> essential_matrix_relpose_5pt_wrapper(const std::vector<Eigen::Vector3d> &x1,
                                                                   const std::vector<Eigen::Vector3d> &x2) {
+    py::gil_scoped_release release;
     std::vector<Eigen::Matrix3d> essential_matrices;
     relpose_5pt(x1, x2, &essential_matrices);
     return essential_matrices;
 }
 std::vector<CameraPose> relpose_5pt_wrapper(const std::vector<Eigen::Vector3d> &x1,
                                             const std::vector<Eigen::Vector3d> &x2) {
+    py::gil_scoped_release release;
     std::vector<CameraPose> output;
     relpose_5pt(x1, x2, &output);
     return output;
 }
 ImagePairVector shared_focal_relpose_6pt_wrapper(const std::vector<Eigen::Vector3d> &x1,
                                                  const std::vector<Eigen::Vector3d> &x2) {
+    py::gil_scoped_release release;
     ImagePairVector output;
     relpose_6pt_shared_focal(x1, x2, &output);
 
@@ -190,12 +211,14 @@ ImagePairVector shared_focal_relpose_6pt_wrapper(const std::vector<Eigen::Vector
 }
 std::vector<CameraPose> relpose_8pt_wrapper(const std::vector<Eigen::Vector3d> &x1,
                                             const std::vector<Eigen::Vector3d> &x2) {
+    py::gil_scoped_release release;
     std::vector<CameraPose> output;
     relpose_8pt(x1, x2, &output);
     return output;
 }
 Eigen::Matrix3d essential_matrix_8pt_wrapper(const std::vector<Eigen::Vector3d> &x1,
                                              const std::vector<Eigen::Vector3d> &x2) {
+    py::gil_scoped_release release;
     Eigen::Matrix3d essential_matrix;
     essential_matrix_8pt(x1, x2, &essential_matrix);
     return essential_matrix;
@@ -203,6 +226,7 @@ Eigen::Matrix3d essential_matrix_8pt_wrapper(const std::vector<Eigen::Vector3d> 
 
 std::vector<CameraPose> relpose_upright_3pt_wrapper(const std::vector<Eigen::Vector3d> &x1,
                                                     const std::vector<Eigen::Vector3d> &x2) {
+    py::gil_scoped_release release;
     std::vector<CameraPose> output;
     relpose_upright_3pt(x1, x2, &output);
     return output;
@@ -212,6 +236,7 @@ std::vector<CameraPose> gen_relpose_upright_4pt_wrapper(const std::vector<Eigen:
                                                         const std::vector<Eigen::Vector3d> &x1,
                                                         const std::vector<Eigen::Vector3d> &p2,
                                                         const std::vector<Eigen::Vector3d> &x2) {
+    py::gil_scoped_release release;
     std::vector<CameraPose> output;
     gen_relpose_upright_4pt(p1, x1, p2, x2, &output);
     return output;
@@ -221,6 +246,7 @@ std::vector<CameraPose> gen_relpose_6pt_wrapper(const std::vector<Eigen::Vector3
                                                 const std::vector<Eigen::Vector3d> &x1,
                                                 const std::vector<Eigen::Vector3d> &p2,
                                                 const std::vector<Eigen::Vector3d> &x2) {
+    py::gil_scoped_release release;
     std::vector<CameraPose> output;
     gen_relpose_6pt(p1, x1, p2, x2, &output);
     return output;
@@ -228,6 +254,7 @@ std::vector<CameraPose> gen_relpose_6pt_wrapper(const std::vector<Eigen::Vector3
 
 std::vector<CameraPose> relpose_upright_planar_2pt_wrapper(const std::vector<Eigen::Vector3d> &x1,
                                                            const std::vector<Eigen::Vector3d> &x2) {
+    py::gil_scoped_release release;
     std::vector<CameraPose> output;
     relpose_upright_planar_2pt(x1, x2, &output);
     return output;
@@ -235,6 +262,7 @@ std::vector<CameraPose> relpose_upright_planar_2pt_wrapper(const std::vector<Eig
 
 std::vector<CameraPose> relpose_upright_planar_3pt_wrapper(const std::vector<Eigen::Vector3d> &x1,
                                                            const std::vector<Eigen::Vector3d> &x2) {
+    py::gil_scoped_release release;
     std::vector<CameraPose> output;
     relpose_upright_planar_3pt(x1, x2, &output);
     return output;
@@ -254,7 +282,9 @@ std::pair<CameraPose, py::dict> estimate_absolute_pose_wrapper(const std::vector
     CameraPose pose;
     std::vector<char> inlier_mask;
 
+    py::gil_scoped_release release;
     RansacStats stats = estimate_absolute_pose(points2D, points3D, camera, ransac_opt, bundle_opt, &pose, &inlier_mask);
+    py::gil_scoped_acquire acquire;
 
     py::dict output_dict;
     write_to_dict(stats, output_dict);
@@ -292,7 +322,10 @@ std::pair<CameraPose, py::dict> refine_absolute_pose_wrapper(const std::vector<E
     bundle_opt.loss_scale *= scale;
 
     CameraPose refined_pose = initial_pose;
+
+    py::gil_scoped_release release;
     BundleStats stats = bundle_adjust(points2D_scaled, points3D, norm_camera, &refined_pose, bundle_opt);
+    py::gil_scoped_acquire acquire;
 
     py::dict output_dict;
     write_to_dict(stats, output_dict);
@@ -321,6 +354,8 @@ std::pair<CameraPose, py::dict> estimate_absolute_pose_pnpl_wrapper(
     bundle_opt.loss_scale = 0.5 * ransac_opt.max_reproj_error;
     update_bundle_options(bundle_opt_dict, bundle_opt);
 
+    py::gil_scoped_release release;
+
     std::vector<Line2D> lines2D;
     std::vector<Line3D> lines3D;
     lines2D.reserve(lines2D_1.size());
@@ -336,6 +371,8 @@ std::pair<CameraPose, py::dict> estimate_absolute_pose_pnpl_wrapper(
 
     RansacStats stats = estimate_absolute_pose_pnpl(points2D, points3D, lines2D, lines3D, camera, ransac_opt,
                                                     bundle_opt, &pose, &inlier_points_mask, &inlier_lines_mask);
+
+    py::gil_scoped_acquire acquire;
 
     py::dict output_dict;
     write_to_dict(stats, output_dict);
@@ -373,6 +410,8 @@ std::pair<CameraPose, py::dict> refine_absolute_pose_pnpl_wrapper(
         line_bundle_opt.loss_scale /= camera.focal();
     }
 
+    py::gil_scoped_release release;
+
     // Setup line objects
     std::vector<Line2D> lines2D;
     std::vector<Line3D> lines3D;
@@ -399,6 +438,8 @@ std::pair<CameraPose, py::dict> refine_absolute_pose_pnpl_wrapper(
     CameraPose refined_pose = initial_pose;
     BundleStats stats =
         bundle_adjust(points2D_calib, points3D, lines2D_calib, lines3D, &refined_pose, bundle_opt, line_bundle_opt);
+
+    py::gil_scoped_acquire acquire;
 
     py::dict output_dict;
     write_to_dict(stats, output_dict);
@@ -432,8 +473,10 @@ std::pair<CameraPose, py::dict> estimate_generalized_absolute_pose_wrapper(
     CameraPose pose;
     std::vector<std::vector<char>> inlier_mask;
 
+    py::gil_scoped_release release;
     RansacStats stats = estimate_generalized_absolute_pose(points2D, points3D, camera_ext, cameras, ransac_opt,
                                                            bundle_opt, &pose, &inlier_mask);
+    py::gil_scoped_acquire acquire;
 
     py::dict output_dict;
     write_to_dict(stats, output_dict);
@@ -465,7 +508,10 @@ refine_generalized_absolute_pose_wrapper(const std::vector<std::vector<Eigen::Ve
     update_bundle_options(bundle_opt_dict, bundle_opt);
 
     CameraPose refined_pose = initial_pose;
+
+    py::gil_scoped_release release;
     BundleStats stats = generalized_bundle_adjust(points2D, points3D, camera_ext, cameras, &refined_pose, bundle_opt);
+    py::gil_scoped_acquire acquire;
 
     py::dict output_dict;
     write_to_dict(stats, output_dict);
@@ -503,8 +549,10 @@ std::pair<CameraPose, py::dict> estimate_relative_pose_wrapper(const std::vector
     CameraPose pose;
     std::vector<char> inlier_mask;
 
+    py::gil_scoped_release release;
     RansacStats stats =
         estimate_relative_pose(points2D_1, points2D_2, camera1, camera2, ransac_opt, bundle_opt, &pose, &inlier_mask);
+    py::gil_scoped_acquire acquire;
 
     py::dict output_dict;
     write_to_dict(stats, output_dict);
@@ -540,8 +588,11 @@ estimate_shared_focal_relative_pose_wrapper(const std::vector<Eigen::Vector2d> p
     std::vector<char> inlier_mask;
 
     std::vector<Image> output;
+
+    py::gil_scoped_release release;
     RansacStats stats = estimate_shared_focal_relative_pose(points2D_1, points2D_2, pp, ransac_opt, bundle_opt,
                                                             &image_pair, &inlier_mask);
+    py::gil_scoped_acquire acquire;
 
     py::dict output_dict;
     write_to_dict(stats, output_dict);
@@ -557,6 +608,8 @@ std::pair<CameraPose, py::dict> refine_relative_pose_wrapper(const std::vector<E
     BundleOptions bundle_opt;
     update_bundle_options(bundle_opt_dict, bundle_opt);
 
+    py::gil_scoped_release release;
+
     // Normalize image points
     std::vector<Eigen::Vector2d> x1_calib = points2D_1;
     std::vector<Eigen::Vector2d> x2_calib = points2D_2;
@@ -569,6 +622,8 @@ std::pair<CameraPose, py::dict> refine_relative_pose_wrapper(const std::vector<E
 
     CameraPose refined_pose = initial_pose;
     BundleStats stats = refine_relpose(x1_calib, x2_calib, &refined_pose, bundle_opt);
+
+    py::gil_scoped_acquire acquire;
 
     py::dict output_dict;
     write_to_dict(stats, output_dict);
@@ -600,7 +655,9 @@ std::pair<Eigen::Matrix3d, py::dict> estimate_fundamental_wrapper(const std::vec
     Eigen::Matrix3d F;
     std::vector<char> inlier_mask;
 
+    py::gil_scoped_release release;
     RansacStats stats = estimate_fundamental(points2D_1, points2D_2, ransac_opt, bundle_opt, &F, &inlier_mask);
+    py::gil_scoped_acquire acquire;
 
     py::dict output_dict;
     write_to_dict(stats, output_dict);
@@ -616,6 +673,8 @@ std::pair<Eigen::Matrix3d, py::dict> refine_fundamental_wrapper(const std::vecto
     BundleOptions bundle_opt;
     update_bundle_options(bundle_opt_dict, bundle_opt);
 
+    py::gil_scoped_release release;
+
     // Normalize image points
     std::vector<Eigen::Vector2d> x1_norm = points2D_1;
     std::vector<Eigen::Vector2d> x2_norm = points2D_2;
@@ -630,6 +689,8 @@ std::pair<Eigen::Matrix3d, py::dict> refine_fundamental_wrapper(const std::vecto
 
     refined_F = T2.transpose() * refined_F * T1;
     refined_F /= refined_F.norm();
+
+    py::gil_scoped_acquire acquire;
 
     py::dict output_dict;
     write_to_dict(stats, output_dict);
@@ -651,7 +712,9 @@ std::pair<Eigen::Matrix3d, py::dict> estimate_homography_wrapper(const std::vect
     Eigen::Matrix3d H;
     std::vector<char> inlier_mask;
 
+    py::gil_scoped_release release;
     RansacStats stats = estimate_homography(points2D_1, points2D_2, ransac_opt, bundle_opt, &H, &inlier_mask);
+    py::gil_scoped_acquire acquire;
 
     py::dict output_dict;
     write_to_dict(stats, output_dict);
@@ -667,6 +730,8 @@ std::pair<Eigen::Matrix3d, py::dict> refine_homography_wrapper(const std::vector
     BundleOptions bundle_opt;
     update_bundle_options(bundle_opt_dict, bundle_opt);
 
+    py::gil_scoped_release release;
+
     // Normalize image points
     std::vector<Eigen::Vector2d> x1_norm = points2D_1;
     std::vector<Eigen::Vector2d> x2_norm = points2D_2;
@@ -681,6 +746,8 @@ std::pair<Eigen::Matrix3d, py::dict> refine_homography_wrapper(const std::vector
 
     refined_H = T2.inverse() * refined_H * T1;
     refined_H /= refined_H.norm();
+
+    py::gil_scoped_acquire acquire;
 
     py::dict output_dict;
     write_to_dict(stats, output_dict);
@@ -702,8 +769,10 @@ std::pair<CameraPose, py::dict> estimate_generalized_relative_pose_wrapper(
     CameraPose pose;
     std::vector<std::vector<char>> inlier_mask;
 
+    py::gil_scoped_release release;
     RansacStats stats = estimate_generalized_relative_pose(matches, camera1_ext, cameras1, camera2_ext, cameras2,
                                                            ransac_opt, bundle_opt, &pose, &inlier_mask);
+    py::gil_scoped_acquire acquire;
 
     py::dict output_dict;
     write_to_dict(stats, output_dict);
@@ -724,6 +793,7 @@ std::pair<CameraPose, py::dict> estimate_generalized_relative_pose_wrapper(
         cameras2.push_back(camera_from_dict(camera_dict));
     }
 
+    py::gil_scoped_release release;
     return estimate_generalized_relative_pose_wrapper(matches, camera1_ext, cameras1, camera2_ext, cameras2,
                                                       ransac_opt_dict, bundle_opt_dict);
 }
@@ -732,6 +802,11 @@ std::pair<CameraPose, py::dict> refine_generalized_relative_pose_wrapper(
     const std::vector<PairwiseMatches> matches, const CameraPose initial_pose,
     const std::vector<CameraPose> &camera1_ext, const std::vector<Camera> &cameras1,
     const std::vector<CameraPose> &camera2_ext, const std::vector<Camera> &cameras2, const py::dict &bundle_opt_dict) {
+
+    BundleOptions bundle_opt;
+    update_bundle_options(bundle_opt_dict, bundle_opt);
+
+    py::gil_scoped_release release;
 
     // Compute normalized matches
     std::vector<PairwiseMatches> calib_matches = matches;
@@ -751,12 +826,12 @@ std::pair<CameraPose, py::dict> refine_generalized_relative_pose_wrapper(
     }
     scaling_factor /= cameras1.size() + cameras2.size();
 
-    BundleOptions bundle_opt;
-    update_bundle_options(bundle_opt_dict, bundle_opt);
     bundle_opt.loss_scale *= scaling_factor;
 
     CameraPose refined_pose = initial_pose;
     BundleStats stats = refine_generalized_relpose(calib_matches, camera1_ext, camera2_ext, &refined_pose, bundle_opt);
+
+    py::gil_scoped_acquire acquire;
 
     py::dict output_dict;
     write_to_dict(stats, output_dict);
@@ -800,8 +875,10 @@ estimate_hybrid_pose_wrapper(const std::vector<Eigen::Vector2d> points2D, const 
     std::vector<char> inliers_mask_2d3d;
     std::vector<std::vector<char>> inliers_mask_2d2d;
 
+    py::gil_scoped_release release;
     RansacStats stats = estimate_hybrid_pose(points2D, points3D, matches_2D_2D, camera, map_ext, map_cameras,
                                              ransac_opt, bundle_opt, &pose, &inliers_mask_2d3d, &inliers_mask_2d2d);
+    py::gil_scoped_acquire acquire;
 
     py::dict output_dict;
     write_to_dict(stats, output_dict);
@@ -841,8 +918,10 @@ std::pair<CameraPose, py::dict> estimate_1D_radial_absolute_pose_wrapper(const s
     CameraPose pose;
     std::vector<char> inlier_mask;
 
+    py::gil_scoped_release release;
     RansacStats stats =
         estimate_1D_radial_absolute_pose(points2D, points3D, ransac_opt, bundle_opt, &pose, &inlier_mask);
+    py::gil_scoped_acquire acquire;
 
     py::dict output_dict;
     write_to_dict(stats, output_dict);
@@ -859,6 +938,7 @@ std::tuple<Camera, Camera, int> focals_from_fundamental_iterative_wrapper(const 
     Camera camera1 = camera_from_dict(camera1_dict);
     Camera camera2 = camera_from_dict(camera2_dict);
 
+    py::gil_scoped_release release;
     return focals_from_fundamental_iterative(F, camera1, camera2, max_iters, weights);
 }
 

--- a/pybind/pyposelib.cc
+++ b/pybind/pyposelib.cc
@@ -30,7 +30,6 @@ py::dict BundleOptions_wrapper(py::dict overwrite) {
 }
 
 std::vector<CameraPose> p3p_wrapper(const std::vector<Eigen::Vector3d> &x, const std::vector<Eigen::Vector3d> &X) {
-    py::gil_scoped_release release;
     std::vector<CameraPose> output;
     p3p(x, X, &output);
     return output;
@@ -38,7 +37,6 @@ std::vector<CameraPose> p3p_wrapper(const std::vector<Eigen::Vector3d> &x, const
 
 std::vector<CameraPose> gp3p_wrapper(const std::vector<Eigen::Vector3d> &p, const std::vector<Eigen::Vector3d> &x,
                                      const std::vector<Eigen::Vector3d> &X) {
-    py::gil_scoped_release release;
     std::vector<CameraPose> output;
     gp3p(p, x, X, &output);
     return output;
@@ -48,7 +46,6 @@ std::pair<std::vector<CameraPose>, std::vector<double>> gp4ps_wrapper(const std:
                                                                       const std::vector<Eigen::Vector3d> &x,
                                                                       const std::vector<Eigen::Vector3d> &X,
                                                                       bool filter_solutions = true) {
-    py::gil_scoped_release release;
     std::vector<CameraPose> output;
     std::vector<double> output_scales;
     gp4ps(p, x, X, &output, &output_scales, filter_solutions);
@@ -59,7 +56,6 @@ std::pair<std::vector<CameraPose>, std::vector<double>> gp4ps_kukelova_wrapper(c
                                                                                const std::vector<Eigen::Vector3d> &x,
                                                                                const std::vector<Eigen::Vector3d> &X,
                                                                                bool filter_solutions = true) {
-    py::gil_scoped_release release;
     std::vector<CameraPose> output;
     std::vector<double> output_scales;
     gp4ps_kukelova(p, x, X, &output, &output_scales, filter_solutions);
@@ -69,7 +65,6 @@ std::pair<std::vector<CameraPose>, std::vector<double>> gp4ps_kukelova_wrapper(c
 std::pair<std::vector<CameraPose>, std::vector<double>> gp4ps_camposeco_wrapper(const std::vector<Eigen::Vector3d> &p,
                                                                                 const std::vector<Eigen::Vector3d> &x,
                                                                                 const std::vector<Eigen::Vector3d> &X) {
-    py::gil_scoped_release release;
     std::vector<CameraPose> output;
     std::vector<double> output_scales;
     gp4ps_camposeco(p, x, X, &output, &output_scales);
@@ -79,7 +74,6 @@ std::pair<std::vector<CameraPose>, std::vector<double>> gp4ps_camposeco_wrapper(
 std::pair<std::vector<CameraPose>, std::vector<double>> p4pf_wrapper(const std::vector<Eigen::Vector2d> &x,
                                                                      const std::vector<Eigen::Vector3d> &X,
                                                                      bool filter_solutions = true) {
-    py::gil_scoped_release release;
     std::vector<CameraPose> output;
     std::vector<double> output_focal;
     p4pf(x, X, &output, &output_focal, filter_solutions);
@@ -89,14 +83,12 @@ std::pair<std::vector<CameraPose>, std::vector<double>> p4pf_wrapper(const std::
 std::vector<CameraPose> p2p2pl_wrapper(const std::vector<Eigen::Vector3d> &xp, const std::vector<Eigen::Vector3d> &Xp,
                                        const std::vector<Eigen::Vector3d> &x, const std::vector<Eigen::Vector3d> &X,
                                        const std::vector<Eigen::Vector3d> &V) {
-    py::gil_scoped_release release;
     std::vector<CameraPose> output;
     p2p2pl(xp, Xp, x, X, V, &output);
     return output;
 }
 
 std::vector<CameraPose> p6lp_wrapper(const std::vector<Eigen::Vector3d> &l, const std::vector<Eigen::Vector3d> &X) {
-    py::gil_scoped_release release;
     std::vector<CameraPose> output;
     p6lp(l, X, &output);
     return output;
@@ -104,7 +96,6 @@ std::vector<CameraPose> p6lp_wrapper(const std::vector<Eigen::Vector3d> &l, cons
 
 std::vector<CameraPose> p5lp_radial_wrapper(const std::vector<Eigen::Vector3d> &l,
                                             const std::vector<Eigen::Vector3d> &X) {
-    py::gil_scoped_release release;
     std::vector<CameraPose> output;
     p5lp_radial(l, X, &output);
     return output;
@@ -113,7 +104,6 @@ std::vector<CameraPose> p5lp_radial_wrapper(const std::vector<Eigen::Vector3d> &
 std::vector<CameraPose> p2p1ll_wrapper(const std::vector<Eigen::Vector3d> &xp, const std::vector<Eigen::Vector3d> &Xp,
                                        const std::vector<Eigen::Vector3d> &l, const std::vector<Eigen::Vector3d> &X,
                                        const std::vector<Eigen::Vector3d> &V) {
-    py::gil_scoped_release release;
     std::vector<CameraPose> output;
     p2p1ll(xp, Xp, l, X, V, &output);
     return output;
@@ -122,7 +112,6 @@ std::vector<CameraPose> p2p1ll_wrapper(const std::vector<Eigen::Vector3d> &xp, c
 std::vector<CameraPose> p1p2ll_wrapper(const std::vector<Eigen::Vector3d> &xp, const std::vector<Eigen::Vector3d> &Xp,
                                        const std::vector<Eigen::Vector3d> &l, const std::vector<Eigen::Vector3d> &X,
                                        const std::vector<Eigen::Vector3d> &V) {
-    py::gil_scoped_release release;
     std::vector<CameraPose> output;
     p1p2ll(xp, Xp, l, X, V, &output);
     return output;
@@ -130,14 +119,12 @@ std::vector<CameraPose> p1p2ll_wrapper(const std::vector<Eigen::Vector3d> &xp, c
 
 std::vector<CameraPose> p3ll_wrapper(const std::vector<Eigen::Vector3d> &l, const std::vector<Eigen::Vector3d> &X,
                                      const std::vector<Eigen::Vector3d> &V) {
-    py::gil_scoped_release release;
     std::vector<CameraPose> output;
     p3ll(l, X, V, &output);
     return output;
 }
 
 std::vector<CameraPose> up2p_wrapper(const std::vector<Eigen::Vector3d> &x, const std::vector<Eigen::Vector3d> &X) {
-    py::gil_scoped_release release;
     std::vector<CameraPose> output;
     up2p(x, X, &output);
     return output;
@@ -145,7 +132,6 @@ std::vector<CameraPose> up2p_wrapper(const std::vector<Eigen::Vector3d> &x, cons
 
 std::vector<CameraPose> ugp2p_wrapper(const std::vector<Eigen::Vector3d> &p, const std::vector<Eigen::Vector3d> &x,
                                       const std::vector<Eigen::Vector3d> &X) {
-    py::gil_scoped_release release;
     std::vector<CameraPose> output;
     ugp2p(p, x, X, &output);
     return output;
@@ -155,7 +141,6 @@ std::pair<std::vector<CameraPose>, std::vector<double>> ugp3ps_wrapper(const std
                                                                        const std::vector<Eigen::Vector3d> &x,
                                                                        const std::vector<Eigen::Vector3d> &X,
                                                                        bool filter_solutions = true) {
-    py::gil_scoped_release release;
     std::vector<CameraPose> output;
     std::vector<double> output_scales;
     ugp3ps(p, x, X, &output, &output_scales, filter_solutions);
@@ -165,7 +150,6 @@ std::pair<std::vector<CameraPose>, std::vector<double>> ugp3ps_wrapper(const std
 std::vector<CameraPose> up1p2pl_wrapper(const std::vector<Eigen::Vector3d> &xp, const std::vector<Eigen::Vector3d> &Xp,
                                         const std::vector<Eigen::Vector3d> &x, const std::vector<Eigen::Vector3d> &X,
                                         const std::vector<Eigen::Vector3d> &V) {
-    py::gil_scoped_release release;
     std::vector<CameraPose> output;
     up1p2pl(xp, Xp, x, X, V, &output);
     return output;
@@ -173,7 +157,6 @@ std::vector<CameraPose> up1p2pl_wrapper(const std::vector<Eigen::Vector3d> &xp, 
 
 std::vector<CameraPose> up4pl_wrapper(const std::vector<Eigen::Vector3d> &x, const std::vector<Eigen::Vector3d> &X,
                                       const std::vector<Eigen::Vector3d> &V) {
-    py::gil_scoped_release release;
     std::vector<CameraPose> output;
     up4pl(x, X, V, &output);
     return output;
@@ -181,7 +164,6 @@ std::vector<CameraPose> up4pl_wrapper(const std::vector<Eigen::Vector3d> &x, con
 
 std::vector<CameraPose> ugp4pl_wrapper(const std::vector<Eigen::Vector3d> &p, const std::vector<Eigen::Vector3d> &x,
                                        const std::vector<Eigen::Vector3d> &X, const std::vector<Eigen::Vector3d> &V) {
-    py::gil_scoped_release release;
     std::vector<CameraPose> output;
     ugp4pl(p, x, X, V, &output);
     return output;
@@ -189,21 +171,18 @@ std::vector<CameraPose> ugp4pl_wrapper(const std::vector<Eigen::Vector3d> &p, co
 
 std::vector<Eigen::Matrix3d> essential_matrix_relpose_5pt_wrapper(const std::vector<Eigen::Vector3d> &x1,
                                                                   const std::vector<Eigen::Vector3d> &x2) {
-    py::gil_scoped_release release;
     std::vector<Eigen::Matrix3d> essential_matrices;
     relpose_5pt(x1, x2, &essential_matrices);
     return essential_matrices;
 }
 std::vector<CameraPose> relpose_5pt_wrapper(const std::vector<Eigen::Vector3d> &x1,
                                             const std::vector<Eigen::Vector3d> &x2) {
-    py::gil_scoped_release release;
     std::vector<CameraPose> output;
     relpose_5pt(x1, x2, &output);
     return output;
 }
 ImagePairVector shared_focal_relpose_6pt_wrapper(const std::vector<Eigen::Vector3d> &x1,
                                                  const std::vector<Eigen::Vector3d> &x2) {
-    py::gil_scoped_release release;
     ImagePairVector output;
     relpose_6pt_shared_focal(x1, x2, &output);
 
@@ -211,14 +190,12 @@ ImagePairVector shared_focal_relpose_6pt_wrapper(const std::vector<Eigen::Vector
 }
 std::vector<CameraPose> relpose_8pt_wrapper(const std::vector<Eigen::Vector3d> &x1,
                                             const std::vector<Eigen::Vector3d> &x2) {
-    py::gil_scoped_release release;
     std::vector<CameraPose> output;
     relpose_8pt(x1, x2, &output);
     return output;
 }
 Eigen::Matrix3d essential_matrix_8pt_wrapper(const std::vector<Eigen::Vector3d> &x1,
                                              const std::vector<Eigen::Vector3d> &x2) {
-    py::gil_scoped_release release;
     Eigen::Matrix3d essential_matrix;
     essential_matrix_8pt(x1, x2, &essential_matrix);
     return essential_matrix;
@@ -226,7 +203,6 @@ Eigen::Matrix3d essential_matrix_8pt_wrapper(const std::vector<Eigen::Vector3d> 
 
 std::vector<CameraPose> relpose_upright_3pt_wrapper(const std::vector<Eigen::Vector3d> &x1,
                                                     const std::vector<Eigen::Vector3d> &x2) {
-    py::gil_scoped_release release;
     std::vector<CameraPose> output;
     relpose_upright_3pt(x1, x2, &output);
     return output;
@@ -236,7 +212,6 @@ std::vector<CameraPose> gen_relpose_upright_4pt_wrapper(const std::vector<Eigen:
                                                         const std::vector<Eigen::Vector3d> &x1,
                                                         const std::vector<Eigen::Vector3d> &p2,
                                                         const std::vector<Eigen::Vector3d> &x2) {
-    py::gil_scoped_release release;
     std::vector<CameraPose> output;
     gen_relpose_upright_4pt(p1, x1, p2, x2, &output);
     return output;
@@ -246,7 +221,6 @@ std::vector<CameraPose> gen_relpose_6pt_wrapper(const std::vector<Eigen::Vector3
                                                 const std::vector<Eigen::Vector3d> &x1,
                                                 const std::vector<Eigen::Vector3d> &p2,
                                                 const std::vector<Eigen::Vector3d> &x2) {
-    py::gil_scoped_release release;
     std::vector<CameraPose> output;
     gen_relpose_6pt(p1, x1, p2, x2, &output);
     return output;
@@ -254,7 +228,6 @@ std::vector<CameraPose> gen_relpose_6pt_wrapper(const std::vector<Eigen::Vector3
 
 std::vector<CameraPose> relpose_upright_planar_2pt_wrapper(const std::vector<Eigen::Vector3d> &x1,
                                                            const std::vector<Eigen::Vector3d> &x2) {
-    py::gil_scoped_release release;
     std::vector<CameraPose> output;
     relpose_upright_planar_2pt(x1, x2, &output);
     return output;
@@ -262,7 +235,6 @@ std::vector<CameraPose> relpose_upright_planar_2pt_wrapper(const std::vector<Eig
 
 std::vector<CameraPose> relpose_upright_planar_3pt_wrapper(const std::vector<Eigen::Vector3d> &x1,
                                                            const std::vector<Eigen::Vector3d> &x2) {
-    py::gil_scoped_release release;
     std::vector<CameraPose> output;
     relpose_upright_planar_3pt(x1, x2, &output);
     return output;
@@ -793,7 +765,6 @@ std::pair<CameraPose, py::dict> estimate_generalized_relative_pose_wrapper(
         cameras2.push_back(camera_from_dict(camera_dict));
     }
 
-    py::gil_scoped_release release;
     return estimate_generalized_relative_pose_wrapper(matches, camera1_ext, cameras1, camera2_ext, cameras2,
                                                       ransac_opt_dict, bundle_opt_dict);
 }
@@ -1027,37 +998,59 @@ PYBIND11_MODULE(poselib, m) {
     m.doc() = "This library provides a collection of minimal solvers for camera pose estimation.";
 
     // Minimal solvers
-    m.def("p3p", &poselib::p3p_wrapper, py::arg("x"), py::arg("X"));
-    m.def("gp3p", &poselib::gp3p_wrapper, py::arg("p"), py::arg("x"), py::arg("X"));
-    m.def("gp4ps", &poselib::gp4ps_wrapper, py::arg("p"), py::arg("x"), py::arg("X"), py::arg("filter_solutions"));
+    m.def("p3p", &poselib::p3p_wrapper, py::arg("x"), py::arg("X"), py::call_guard<py::gil_scoped_release>());
+    m.def("gp3p", &poselib::gp3p_wrapper, py::arg("p"), py::arg("x"), py::arg("X"),
+          py::call_guard<py::gil_scoped_release>());
+    m.def("gp4ps", &poselib::gp4ps_wrapper, py::arg("p"), py::arg("x"), py::arg("X"), py::arg("filter_solutions"),
+          py::call_guard<py::gil_scoped_release>());
     m.def("gp4ps_kukelova", &poselib::gp4ps_kukelova_wrapper, py::arg("p"), py::arg("x"), py::arg("X"),
-          py::arg("filter_solutions"));
-    m.def("gp4ps_camposeco", &poselib::gp4ps_camposeco_wrapper, py::arg("p"), py::arg("x"), py::arg("X"));
-    m.def("p4pf", &poselib::p4pf_wrapper, py::arg("x"), py::arg("X"), py::arg("filter_solutions"));
-    m.def("p2p2pl", &poselib::p2p2pl_wrapper, py::arg("xp"), py::arg("Xp"), py::arg("x"), py::arg("X"), py::arg("V"));
-    m.def("p6lp", &poselib::p6lp_wrapper, py::arg("l"), py::arg("X"));
-    m.def("p5lp_radial", &poselib::p5lp_radial_wrapper, py::arg("l"), py::arg("X"));
-    m.def("p2p1ll", &poselib::p2p1ll_wrapper, py::arg("xp"), py::arg("Xp"), py::arg("l"), py::arg("X"), py::arg("V"));
-    m.def("p1p2ll", &poselib::p1p2ll_wrapper, py::arg("xp"), py::arg("Xp"), py::arg("l"), py::arg("X"), py::arg("V"));
-    m.def("p3ll", &poselib::p3ll_wrapper, py::arg("l"), py::arg("X"), py::arg("V"));
-    m.def("up2p", &poselib::up2p_wrapper, py::arg("x"), py::arg("X"));
-    m.def("ugp2p", &poselib::ugp2p_wrapper, py::arg("p"), py::arg("x"), py::arg("X"));
-    m.def("ugp3ps", &poselib::ugp3ps_wrapper, py::arg("p"), py::arg("x"), py::arg("X"), py::arg("filter_solutions"));
-    m.def("up1p2pl", &poselib::up1p2pl_wrapper, py::arg("xp"), py::arg("Xp"), py::arg("x"), py::arg("X"), py::arg("V"));
-    m.def("up4pl", &poselib::up4pl_wrapper, py::arg("x"), py::arg("X"), py::arg("V"));
-    m.def("ugp4pl", &poselib::ugp4pl_wrapper, py::arg("p"), py::arg("x"), py::arg("X"), py::arg("V"));
-    m.def("essential_matrix_5pt", &poselib::essential_matrix_relpose_5pt_wrapper, py::arg("x1"), py::arg("x2"));
-    m.def("shared_focal_relpose_6pt", &poselib::shared_focal_relpose_6pt_wrapper, py::arg("x1"), py::arg("x2"));
-    m.def("relpose_5pt", &poselib::relpose_5pt_wrapper, py::arg("x1"), py::arg("x2"));
-    m.def("relpose_8pt", &poselib::relpose_8pt_wrapper, py::arg("x1"), py::arg("x2"));
-    m.def("essential_matrix_8pt", &poselib::essential_matrix_8pt_wrapper, py::arg("x1"), py::arg("x2"));
-    m.def("relpose_upright_3pt", &poselib::relpose_upright_3pt_wrapper, py::arg("x1"), py::arg("x2"));
+          py::arg("filter_solutions"), py::call_guard<py::gil_scoped_release>());
+    m.def("gp4ps_camposeco", &poselib::gp4ps_camposeco_wrapper, py::arg("p"), py::arg("x"), py::arg("X"),
+          py::call_guard<py::gil_scoped_release>());
+    m.def("p4pf", &poselib::p4pf_wrapper, py::arg("x"), py::arg("X"), py::arg("filter_solutions"),
+          py::call_guard<py::gil_scoped_release>());
+    m.def("p2p2pl", &poselib::p2p2pl_wrapper, py::arg("xp"), py::arg("Xp"), py::arg("x"), py::arg("X"), py::arg("V"),
+          py::call_guard<py::gil_scoped_release>());
+    m.def("p6lp", &poselib::p6lp_wrapper, py::arg("l"), py::arg("X"), py::call_guard<py::gil_scoped_release>());
+    m.def("p5lp_radial", &poselib::p5lp_radial_wrapper, py::arg("l"), py::arg("X"),
+          py::call_guard<py::gil_scoped_release>());
+    m.def("p2p1ll", &poselib::p2p1ll_wrapper, py::arg("xp"), py::arg("Xp"), py::arg("l"), py::arg("X"), py::arg("V"),
+          py::call_guard<py::gil_scoped_release>());
+    m.def("p1p2ll", &poselib::p1p2ll_wrapper, py::arg("xp"), py::arg("Xp"), py::arg("l"), py::arg("X"), py::arg("V"),
+          py::call_guard<py::gil_scoped_release>());
+    m.def("p3ll", &poselib::p3ll_wrapper, py::arg("l"), py::arg("X"), py::arg("V"),
+          py::call_guard<py::gil_scoped_release>());
+    m.def("up2p", &poselib::up2p_wrapper, py::arg("x"), py::arg("X"), py::call_guard<py::gil_scoped_release>());
+    m.def("ugp2p", &poselib::ugp2p_wrapper, py::arg("p"), py::arg("x"), py::arg("X"),
+          py::call_guard<py::gil_scoped_release>());
+    m.def("ugp3ps", &poselib::ugp3ps_wrapper, py::arg("p"), py::arg("x"), py::arg("X"), py::arg("filter_solutions"),
+          py::call_guard<py::gil_scoped_release>());
+    m.def("up1p2pl", &poselib::up1p2pl_wrapper, py::arg("xp"), py::arg("Xp"), py::arg("x"), py::arg("X"), py::arg("V"),
+          py::call_guard<py::gil_scoped_release>());
+    m.def("up4pl", &poselib::up4pl_wrapper, py::arg("x"), py::arg("X"), py::arg("V"),
+          py::call_guard<py::gil_scoped_release>());
+    m.def("ugp4pl", &poselib::ugp4pl_wrapper, py::arg("p"), py::arg("x"), py::arg("X"), py::arg("V"),
+          py::call_guard<py::gil_scoped_release>());
+    m.def("essential_matrix_5pt", &poselib::essential_matrix_relpose_5pt_wrapper, py::arg("x1"), py::arg("x2"),
+          py::call_guard<py::gil_scoped_release>());
+    m.def("shared_focal_relpose_6pt", &poselib::shared_focal_relpose_6pt_wrapper, py::arg("x1"), py::arg("x2"),
+          py::call_guard<py::gil_scoped_release>());
+    m.def("relpose_5pt", &poselib::relpose_5pt_wrapper, py::arg("x1"), py::arg("x2"),
+          py::call_guard<py::gil_scoped_release>());
+    m.def("relpose_8pt", &poselib::relpose_8pt_wrapper, py::arg("x1"), py::arg("x2"),
+          py::call_guard<py::gil_scoped_release>());
+    m.def("essential_matrix_8pt", &poselib::essential_matrix_8pt_wrapper, py::arg("x1"), py::arg("x2"),
+          py::call_guard<py::gil_scoped_release>());
+    m.def("relpose_upright_3pt", &poselib::relpose_upright_3pt_wrapper, py::arg("x1"), py::arg("x2"),
+          py::call_guard<py::gil_scoped_release>());
     m.def("gen_relpose_upright_4pt", &poselib::gen_relpose_upright_4pt_wrapper, py::arg("p1"), py::arg("x1"),
-          py::arg("p2"), py::arg("x2"));
+          py::arg("p2"), py::arg("x2"), py::call_guard<py::gil_scoped_release>());
     m.def("gen_relpose_6pt", &poselib::gen_relpose_6pt_wrapper, py::arg("p1"), py::arg("x1"), py::arg("p2"),
-          py::arg("x2"));
-    m.def("relpose_upright_planar_2pt", &poselib::relpose_upright_planar_2pt_wrapper, py::arg("x1"), py::arg("x2"));
-    m.def("relpose_upright_planar_3pt", &poselib::relpose_upright_planar_3pt_wrapper, py::arg("x1"), py::arg("x2"));
+          py::arg("x2"), py::call_guard<py::gil_scoped_release>());
+    m.def("relpose_upright_planar_2pt", &poselib::relpose_upright_planar_2pt_wrapper, py::arg("x1"), py::arg("x2"),
+          py::call_guard<py::gil_scoped_release>());
+    m.def("relpose_upright_planar_3pt", &poselib::relpose_upright_planar_3pt_wrapper, py::arg("x1"), py::arg("x2"),
+          py::call_guard<py::gil_scoped_release>());
 
     // Robust estimators
     m.def("estimate_absolute_pose",


### PR DESCRIPTION
This enables multithreading from within python. Example experiment:
```python
import concurrent.futures
import time

import numpy as np
import poselib

num_tasks = 100

# Prepare task
camera = {
    "model": "SIMPLE_PINHOLE",
    "width": 1280,
    "height": 720,
    "params": [1.2 * 1280, 1280/2, 720/2]
}
points2D_1 = np.random.uniform(low=0.0, high=720, size=(100, 2))
points2D_2 = np.random.uniform(low=0.0, high=720, size=(100, 2))

now = time.time()

with concurrent.futures.ThreadPoolExecutor() as e:
    for _ in range(num_tasks):
        e.submit(poselib.estimate_relative_pose, points2D_1, points2D_2,
                 camera, camera)

then = time.time()

print(f"Done in {then - now} seconds")
```
Output on my machine before:
```
Done in 46.720627784729004 seconds
```
After:
```
Done in 2.9223525524139404 seconds
```