### PR TITLE
Add numpy as a dependency for the python wheel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -82,4 +82,5 @@ setup(
     ext_modules=[CMakeExtension("pyposelib")],
     cmdclass={"build_ext": CMakeBuild},
     zip_safe=False,
+    install_requires=["numpy"],
 )


### PR DESCRIPTION
Can't import poselib without numpy.