### PR TITLE
Updated RANSAC stopping condition

### DIFF
--- a/PoseLib/robust/ransac_impl.h
+++ b/PoseLib/robust/ransac_impl.h
@@ -126,7 +126,7 @@ RansacStats ransac(Solver &estimator, const RansacOptions &opt, Model *best_mode
     std::vector<Model> models;
     for (stats.iterations = 0; stats.iterations < opt.max_iterations; stats.iterations++) {
 
-        if (stats.iterations > opt.min_iterations && stats.iterations > state.dynamic_max_iter) {
+        if (stats.iterations > opt.min_iterations || stats.iterations > state.dynamic_max_iter) {
             break;
         }
         models.clear();


### PR DESCRIPTION
@vlarsson If the current iterations reach a number over `state.dynamic_max_iter` it should also stop? 