### PR TITLE
Estimator for relative pose with two unknown focal lenghts

### DIFF
--- a/PoseLib/robust.cc
+++ b/PoseLib/robust.cc
@@ -423,6 +423,65 @@ RansacStats estimate_shared_focal_relative_pose(const std::vector<Point2D> &poin
     return stats;
 }
 
+RansacStats estimate_varying_focal_relative_pose(const std::vector<Point2D> &points2D_1,
+                                                 const std::vector<Point2D> &points2D_2, const Point2D &pp1,
+                                                 const Point2D &pp2, const RelativePoseOptions &opt,
+                                                 ImagePair *image_pair, std::vector<char> *inliers) {
+    const size_t num_pts = points2D_1.size();
+
+    Eigen::Matrix3d T1, T2;
+    std::vector<Point2D> x1_norm = points2D_1;
+    std::vector<Point2D> x2_norm = points2D_2;
+
+    for (size_t i = 0; i < x1_norm.size(); i++) {
+        x1_norm[i] -= pp1;
+        x2_norm[i] -= pp2;
+    }
+
+    // Normalize points (scale only, no shift since pp is now at origin)
+    double scale = normalize_points(x1_norm, x2_norm, T1, T2, true, false, true);
+
+    RelativePoseOptions opt_scaled = opt;
+    opt_scaled.max_error /= scale;
+    opt_scaled.bundle.loss_scale /= scale;
+
+    if (opt.ransac.score_initial_model) {
+        image_pair->camera1 = Camera(SimplePinholeCameraModel::model_id,
+                                     std::vector<double>{image_pair->camera1.focal() / scale, 0.0, 0.0}, -1, -1);
+        image_pair->camera2 = Camera(SimplePinholeCameraModel::model_id,
+                                     std::vector<double>{image_pair->camera2.focal() / scale, 0.0, 0.0}, -1, -1);
+    }
+
+    RansacStats stats = ransac_varying_focal_relpose(x1_norm, x2_norm, opt_scaled, image_pair, inliers);
+
+    if (stats.num_inliers > 7) {
+        std::vector<Point2D> x1_inliers;
+        std::vector<Point2D> x2_inliers;
+        x1_inliers.reserve(stats.num_inliers);
+        x2_inliers.reserve(stats.num_inliers);
+
+        for (size_t k = 0; k < num_pts; ++k) {
+            if (!(*inliers)[k])
+                continue;
+            x1_inliers.push_back(x1_norm[k]);
+            x2_inliers.push_back(x2_norm[k]);
+        }
+
+        refine_varying_focal_relpose(x1_inliers, x2_inliers, image_pair, opt_scaled.bundle);
+    }
+
+    // Rescale focal lengths back to original scale and set principal points
+    image_pair->camera1.params[0] *= scale;
+    image_pair->camera1.params[1] = pp1(0);
+    image_pair->camera1.params[2] = pp1(1);
+
+    image_pair->camera2.params[0] *= scale;
+    image_pair->camera2.params[1] = pp2(0);
+    image_pair->camera2.params[2] = pp2(1);
+
+    return stats;
+}
+
 RansacStats estimate_shared_focal_monodepth_relative_pose(const std::vector<Point2D> &points2D_1,
                                                           const std::vector<Point2D> &points2D_2,
                                                           const std::vector<double> &depth_1,

--- a/PoseLib/robust.cc
+++ b/PoseLib/robust.cc
@@ -485,7 +485,7 @@ RansacStats estimate_varying_focal_relative_pose(const std::vector<Point2D> &poi
 RansacStats estimate_shared_focal_monodepth_relative_pose(const std::vector<Point2D> &points2D_1,
                                                           const std::vector<Point2D> &points2D_2,
                                                           const std::vector<double> &depth_1,
-                                                          const std::vector<double> &depth_2,
+                                                          const std::vector<double> &depth_2, const Point2D &pp,
                                                           const MonoDepthRelativePoseOptions &opt,
                                                           MonoDepthImagePair *image_pair, std::vector<char> *inliers) {
 
@@ -494,6 +494,11 @@ RansacStats estimate_shared_focal_monodepth_relative_pose(const std::vector<Poin
     Eigen::Matrix3d T1, T2;
     std::vector<Point2D> x1_norm = points2D_1;
     std::vector<Point2D> x2_norm = points2D_2;
+
+    for (size_t i = 0; i < x1_norm.size(); i++) {
+        x1_norm[i] -= pp;
+        x2_norm[i] -= pp;
+    }
 
     // We normalize points here to improve conditioning. Note that the normalization
     // only ammounts to a uniform rescaling of the image coordinate system
@@ -536,8 +541,8 @@ RansacStats estimate_shared_focal_monodepth_relative_pose(const std::vector<Poin
 
     // rescale back
     image_pair->camera1.params[0] *= scale;
-    image_pair->camera1.params[1] = 0; // pp(0);
-    image_pair->camera1.params[2] = 0; // pp(1);
+    image_pair->camera1.params[1] = pp(0);
+    image_pair->camera1.params[2] = pp(1);
     image_pair->camera2 = image_pair->camera1;
 
     return stats;
@@ -546,14 +551,19 @@ RansacStats estimate_shared_focal_monodepth_relative_pose(const std::vector<Poin
 RansacStats estimate_varying_focal_monodepth_relative_pose(const std::vector<Point2D> &points2D_1,
                                                            const std::vector<Point2D> &points2D_2,
                                                            const std::vector<double> &depth_1,
-                                                           const std::vector<double> &depth_2,
-                                                           const MonoDepthRelativePoseOptions &opt,
+                                                           const std::vector<double> &depth_2, const Point2D &pp1,
+                                                           const Point2D &pp2, const MonoDepthRelativePoseOptions &opt,
                                                            MonoDepthImagePair *image_pair, std::vector<char> *inliers) {
     const size_t num_pts = points2D_1.size();
 
     Eigen::Matrix3d T1, T2;
     std::vector<Point2D> x1_norm = points2D_1;
     std::vector<Point2D> x2_norm = points2D_2;
+
+    for (size_t i = 0; i < x1_norm.size(); i++) {
+        x1_norm[i] -= pp1;
+        x2_norm[i] -= pp2;
+    }
 
     // We normalize points here to improve conditioning. Note that the normalization
     // only ammounts to a uniform rescaling of the image coordinate system
@@ -595,7 +605,12 @@ RansacStats estimate_varying_focal_monodepth_relative_pose(const std::vector<Poi
 
     // rescale back
     image_pair->camera1.params[0] *= scale;
+    image_pair->camera1.params[1] = pp1(0);
+    image_pair->camera1.params[2] = pp1(1);
+
     image_pair->camera2.params[0] *= scale;
+    image_pair->camera2.params[1] = pp2(0);
+    image_pair->camera2.params[2] = pp2(1);
 
     return stats;
 }

--- a/PoseLib/robust.h
+++ b/PoseLib/robust.h
@@ -40,13 +40,13 @@
 namespace poselib {
 
 // Estimates absolute pose using LO-RANSAC followed by non-linear refinement
-// Threshold for reprojection error is set by RansacOptions.max_reproj_error
-// If ransac_opt.estimate_focal, the camera in image.camera should contain correct principal point
+// Threshold for reprojection error is set by AbsolutePoseOptions.max_error
+// If opt.estimate_focal_length, the camera in image.camera should contain correct principal point
 RansacStats estimate_absolute_pose(const std::vector<Point2D> &points2D, const std::vector<Point3D> &points3D,
                                    AbsolutePoseOptions opt, Image *image, std::vector<char> *inliers);
 
 // Estimates generalized absolute pose using LO-RANSAC followed by non-linear refinement
-// Threshold for reprojection error is set by RansacOptions.max_reproj_error
+// Threshold for reprojection error is set by AbsolutePoseOptions.max_error
 RansacStats estimate_generalized_absolute_pose(const std::vector<std::vector<Point2D>> &points2D,
                                                const std::vector<std::vector<Point3D>> &points3D,
                                                const std::vector<CameraPose> &camera_ext,
@@ -56,21 +56,22 @@ RansacStats estimate_generalized_absolute_pose(const std::vector<std::vector<Poi
 // Estimates absolute pose using LO-RANSAC followed by non-linear refinement
 // using both 2D-3D point and line matches
 // Note that line segments are described by their endpoints
-// Threshold for point reprojection error is set by RansacOptions.max_reproj_error
-// and for lines the threshold is set by RansacOptions.max_epipolar_error
+// Threshold for point reprojection error is set by AbsolutePoseOptions.max_errors[0]
+// and for lines the threshold is set by AbsolutePoseOptions.max_errors[1]
+// (If max_errors is empty, AbsolutePoseOptions.max_error is used for both)
 RansacStats estimate_absolute_pose_pnpl(const std::vector<Point2D> &points2D, const std::vector<Point3D> &points3D,
                                         const std::vector<Line2D> &line2D, const std::vector<Line3D> &line3D,
                                         const Camera &camera, const AbsolutePoseOptions &opt, CameraPose *pose,
                                         std::vector<char> *inliers_points, std::vector<char> *inliers_lines);
 
 // Estimates relative pose using LO-RANSAC followed by non-linear refinement
-// Threshold for Sampson error is set by RansacOptions.max_epipolar_error
+// Threshold for Sampson error is set by RelativePoseOptions.max_error
 RansacStats estimate_relative_pose(const std::vector<Point2D> &points2D_1, const std::vector<Point2D> &points2D_2,
                                    const Camera &camera1, const Camera &camera2, const RelativePoseOptions &opt,
                                    CameraPose *relative_pose, std::vector<char> *inliers);
 
 // Estimates relative geometry from using points and estimated depth using LO-RANSAC followed by non-linear refinement
-// Threshold for Sampson error is set by RansacOptions.max_epipolar_error
+// Threshold for reprojection and epipolar errors are set by MonoDepthRelativePoseOptions.max_errors
 // MonoDepth relative pose estimation with known calibration
 // Uses hybrid scoring with reprojection and epipolar errors
 RansacStats estimate_monodepth_relative_pose(const std::vector<Point2D> &points2D_1,
@@ -80,14 +81,16 @@ RansacStats estimate_monodepth_relative_pose(const std::vector<Point2D> &points2
                                              MonoDepthTwoViewGeometry *geometry, std::vector<char> *inliers);
 
 // Estimates relative pose with shared unknown focal length using LO-RANSAC followed by non-linear refinement
-// Threshold for Sampson error is set by RansacOptions.max_epipolar_error
+// Threshold for Sampson error is set by RelativePoseOptions.max_error
 RansacStats estimate_shared_focal_relative_pose(const std::vector<Point2D> &points2D_1,
                                                 const std::vector<Point2D> &points2D_2, const Point2D &pp,
                                                 const RelativePoseOptions &opt, ImagePair *image_pair,
                                                 std::vector<char> *inliers);
 
 // Estimates relative pose with two different unknown focal lengths using LO-RANSAC followed by non-linear refinement
-// Threshold for Sampson error is set by RansacOptions.max_epipolar_error
+// Threshold for Sampson error is set by RelativePoseOptions.max_error.
+// Uses the Bougnoux (ICCV 1998) decomposition of F for each solution then refines pose and focals directly.
+// This was used as baseline in Ding. et al. (ICCV 2025) and Kocur et al. (IJCV 2026).
 RansacStats estimate_varying_focal_relative_pose(const std::vector<Point2D> &points2D_1,
                                                  const std::vector<Point2D> &points2D_2, const Point2D &pp1,
                                                  const Point2D &pp2, const RelativePoseOptions &opt,
@@ -115,7 +118,9 @@ RansacStats estimate_varying_focal_monodepth_relative_pose(const std::vector<Poi
 
 // Estimates a fundamental matrix using LO-RANSAC followed by non-linear refinement
 // NOTE: USE estimate_relative_pose IF YOU KNOW THE INTRINSICS!!!
-// Threshold for Sampson error is set by RansacOptions.max_epipolar_error
+// If you want to decompose the fundamental matrix into two different focal lenghts and pose after estimation you
+// should use estimate_varying_focal_relative_pose instead.
+// Threshold for Sampson error is set by RelativePoseOptions.max_error
 RansacStats estimate_fundamental(const std::vector<Point2D> &points2D_1, const std::vector<Point2D> &points2D_2,
                                  const RelativePoseOptions &opt, Eigen::Matrix3d *F, std::vector<char> *inliers);
 
@@ -136,12 +141,12 @@ RansacStats estimate_shared_rd_fundamental(const std::vector<Point2D> &x1, const
 
 // Estimates a homography matrix using LO-RANSAC followed by non-linear refinement
 // Convention is x2 = H*x1
-// Threshold for transfer error is set by RansacOptions.max_reproj_error
+// Threshold for transfer error is set by HomographyOptions.max_error
 RansacStats estimate_homography(const std::vector<Point2D> &points2D_1, const std::vector<Point2D> &points2D_2,
                                 const HomographyOptions &opt, Eigen::Matrix3d *H, std::vector<char> *inliers);
 
 // Estimates generalized relative pose using LO-RANSAC followed by non-linear refinement
-// Threshold for Sampson error is set by RansacOptions.max_epipolar_error
+// Threshold for Sampson error is set by RelativePoseOptions.max_error
 RansacStats estimate_generalized_relative_pose(const std::vector<PairwiseMatches> &matches,
                                                const std::vector<CameraPose> &camera1_ext,
                                                const std::vector<Camera> &cameras1,
@@ -150,6 +155,7 @@ RansacStats estimate_generalized_relative_pose(const std::vector<PairwiseMatches
                                                CameraPose *relative_pose, std::vector<std::vector<char>> *inliers);
 
 // Estimates camera pose from hybrid correspondences using LO-RANSAC followed by non-linear refinement
+// Thresholds for 2D-3D and 2D-2D errors are set by HybridPoseOptions.max_errors
 //  camera are the intrinsics for the query camera
 //  (points2D, points3D) are the 2D-3D matches
 //  (matches2D_2D, map_ext, map_cameras) are the 2D-2D matches to the map images with extrinsics/intrinsics
@@ -179,7 +185,7 @@ RansacStats estimate_generalized_hybrid_pose(
 
 // Estimates the 1D absolute pose using LO-RANSAC followed by non-linear refinement
 // Assumes that the image points are centered already
-// Threshold for radial reprojection error is set by RansacOptions.max_reproj_error
+// Threshold for radial reprojection error is set by AbsolutePoseOptions.max_error
 RansacStats estimate_1D_radial_absolute_pose(const std::vector<Point2D> &points2D, const std::vector<Point3D> &points3D,
                                              const AbsolutePoseOptions &opt, CameraPose *pose,
                                              std::vector<char> *inliers);

--- a/PoseLib/robust.h
+++ b/PoseLib/robust.h
@@ -97,23 +97,23 @@ RansacStats estimate_varying_focal_relative_pose(const std::vector<Point2D> &poi
                                                  ImagePair *image_pair, std::vector<char> *inliers);
 
 // Estimates relative pose with shared unknown focal length from point correspondences with estimated monodepth
-// using LO-RANSAC followed by non-linear refinement. The points are assumed to be normalized such that pp = [0,0].
+// using LO-RANSAC followed by non-linear refinement.
 // Uses hybrid scoring with reprojection and epipolar errors
 RansacStats estimate_shared_focal_monodepth_relative_pose(const std::vector<Point2D> &points2D_1,
                                                           const std::vector<Point2D> &points2D_2,
                                                           const std::vector<double> &depths_1,
-                                                          const std::vector<double> &depths_2,
+                                                          const std::vector<double> &depths_2, const Point2D &pp,
                                                           const MonoDepthRelativePoseOptions &opt,
                                                           MonoDepthImagePair *image_pair, std::vector<char> *inliers);
 
 // Estimates relative pose with two different unknown focal lengths from point correspondences with estimated monodepth
-// using LO-RANSAC followed by non-linear refinement. The points are assumed to be normalized such that pp = [0,0].
+// using LO-RANSAC followed by non-linear refinement.
 // Uses hybrid scoring with reprojection and epipolar errors
 RansacStats estimate_varying_focal_monodepth_relative_pose(const std::vector<Point2D> &points2D_1,
                                                            const std::vector<Point2D> &points2D_2,
                                                            const std::vector<double> &depth_1,
-                                                           const std::vector<double> &depth_2,
-                                                           const MonoDepthRelativePoseOptions &opt,
+                                                           const std::vector<double> &depth_2, const Point2D &pp1,
+                                                           const Point2D &pp2, const MonoDepthRelativePoseOptions &opt,
                                                            MonoDepthImagePair *image_pair, std::vector<char> *inliers);
 
 // Estimates a fundamental matrix using LO-RANSAC followed by non-linear refinement

--- a/PoseLib/robust.h
+++ b/PoseLib/robust.h
@@ -86,6 +86,13 @@ RansacStats estimate_shared_focal_relative_pose(const std::vector<Point2D> &poin
                                                 const RelativePoseOptions &opt, ImagePair *image_pair,
                                                 std::vector<char> *inliers);
 
+// Estimates relative pose with two different unknown focal lengths using LO-RANSAC followed by non-linear refinement
+// Threshold for Sampson error is set by RansacOptions.max_epipolar_error
+RansacStats estimate_varying_focal_relative_pose(const std::vector<Point2D> &points2D_1,
+                                                 const std::vector<Point2D> &points2D_2, const Point2D &pp1,
+                                                 const Point2D &pp2, const RelativePoseOptions &opt,
+                                                 ImagePair *image_pair, std::vector<char> *inliers);
+
 // Estimates relative pose with shared unknown focal length from point correspondences with estimated monodepth
 // using LO-RANSAC followed by non-linear refinement. The points are assumed to be normalized such that pp = [0,0].
 // Uses hybrid scoring with reprojection and epipolar errors

--- a/PoseLib/robust/bundle.cc
+++ b/PoseLib/robust/bundle.cc
@@ -299,13 +299,24 @@ BundleStats refine_shared_focal_relpose(const std::vector<Point2D> &x1, const st
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////
-// TODO: Entry point for relative pose with two different unknown focals refinement
-// Not yet implemented in dev's refiner architecture
-// BundleStats refine_varying_focal_relpose(const std::vector<Point2D> &x1, const std::vector<Point2D> &x2,
-//                                          ImagePair *image_pair, const BundleOptions &opt,
-//                                          const std::vector<double> &weights) {
-//     // Implementation needed
-// }
+template <typename WeightType>
+BundleStats refine_varying_focal_relpose(const std::vector<Point2D> &x1, const std::vector<Point2D> &x2,
+                                        ImagePair *image_pair, const BundleOptions &opt, const WeightType &weights) {
+    IterationCallback callback = setup_callback(opt);
+    VaryingFocalRelativePoseRefiner<decltype(weights)> refiner(x1, x2, weights);
+    return lm_impl<decltype(refiner)>(refiner, image_pair, opt, callback);
+}
+
+// Entry point for relative pose with unknown varying focal refinement
+BundleStats refine_varying_focal_relpose(const std::vector<Point2D> &x1, const std::vector<Point2D> &x2,
+                                        ImagePair *image_pair, const BundleOptions &opt,
+                                        const std::vector<double> &weights) {
+    if (weights.size() == x1.size()) {
+        return refine_varying_focal_relpose<std::vector<double>>(x1, x2, image_pair, opt, weights);
+    } else {
+        return refine_varying_focal_relpose<UniformWeightVector>(x1, x2, image_pair, opt, UniformWeightVector());
+    }
+}
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////
 // Uncalibrated relative pose (fundamental matrix) refinement
@@ -582,6 +593,7 @@ BundleStats refine_monodepth_varying_focal_relpose(const std::vector<Point2D> &x
     return lm_impl<decltype(refiner)>(refiner, image_pair, opt, callback);
 }
 
+///////////////////////////////////////////////////////////////////////////////////////////////////////
 // Entry point for monodepth varying focal relative pose refinement
 BundleStats refine_monodepth_varying_focal_relpose(const std::vector<Point2D> &x1, const std::vector<Point2D> &x2,
                                                    const std::vector<double> &d1, const std::vector<double> &d2,

--- a/PoseLib/robust/bundle.cc
+++ b/PoseLib/robust/bundle.cc
@@ -301,7 +301,7 @@ BundleStats refine_shared_focal_relpose(const std::vector<Point2D> &x1, const st
 ///////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename WeightType>
 BundleStats refine_varying_focal_relpose(const std::vector<Point2D> &x1, const std::vector<Point2D> &x2,
-                                        ImagePair *image_pair, const BundleOptions &opt, const WeightType &weights) {
+                                         ImagePair *image_pair, const BundleOptions &opt, const WeightType &weights) {
     IterationCallback callback = setup_callback(opt);
     VaryingFocalRelativePoseRefiner<decltype(weights)> refiner(x1, x2, weights);
     return lm_impl<decltype(refiner)>(refiner, image_pair, opt, callback);
@@ -309,8 +309,8 @@ BundleStats refine_varying_focal_relpose(const std::vector<Point2D> &x1, const s
 
 // Entry point for relative pose with unknown varying focal refinement
 BundleStats refine_varying_focal_relpose(const std::vector<Point2D> &x1, const std::vector<Point2D> &x2,
-                                        ImagePair *image_pair, const BundleOptions &opt,
-                                        const std::vector<double> &weights) {
+                                         ImagePair *image_pair, const BundleOptions &opt,
+                                         const std::vector<double> &weights) {
     if (weights.size() == x1.size()) {
         return refine_varying_focal_relpose<std::vector<double>>(x1, x2, image_pair, opt, weights);
     } else {

--- a/PoseLib/robust/bundle.h
+++ b/PoseLib/robust/bundle.h
@@ -109,7 +109,7 @@ BundleStats refine_shared_focal_relpose(const std::vector<Point2D> &x1, const st
                                         ImagePair *image_pair, const BundleOptions &opt = BundleOptions(),
                                         const std::vector<double> &weights = std::vector<double>());
 
-// TODO: Relative pose with two different unknown focals refinement not yet implemented in dev's refiner architecture
+// Relative pose with two different unknown focals refinement. Minimizes Sampson error error.
 BundleStats refine_varying_focal_relpose(const std::vector<Point2D> &x1, const std::vector<Point2D> &x2,
                                          ImagePair *image_pair, const BundleOptions &opt = BundleOptions(),
                                          const std::vector<double> &weights = std::vector<double>());

--- a/PoseLib/robust/bundle.h
+++ b/PoseLib/robust/bundle.h
@@ -110,9 +110,9 @@ BundleStats refine_shared_focal_relpose(const std::vector<Point2D> &x1, const st
                                         const std::vector<double> &weights = std::vector<double>());
 
 // TODO: Relative pose with two different unknown focals refinement not yet implemented in dev's refiner architecture
-// BundleStats refine_varying_focal_relpose(const std::vector<Point2D> &x1, const std::vector<Point2D> &x2,
-//                                          ImagePair *image_pair, const BundleOptions &opt = BundleOptions(),
-//                                          const std::vector<double> &weights = std::vector<double>());
+ BundleStats refine_varying_focal_relpose(const std::vector<Point2D> &x1, const std::vector<Point2D> &x2,
+                                          ImagePair *image_pair, const BundleOptions &opt = BundleOptions(),
+                                          const std::vector<double> &weights = std::vector<double>());
 
 // Relative pose with single unknown focal refinement. Minimizes Reprojection error using monodepth estimates.
 BundleStats refine_monodepth_shared_focal_relpose(const std::vector<Point2D> &x1, const std::vector<Point2D> &x2,

--- a/PoseLib/robust/bundle.h
+++ b/PoseLib/robust/bundle.h
@@ -110,9 +110,9 @@ BundleStats refine_shared_focal_relpose(const std::vector<Point2D> &x1, const st
                                         const std::vector<double> &weights = std::vector<double>());
 
 // TODO: Relative pose with two different unknown focals refinement not yet implemented in dev's refiner architecture
- BundleStats refine_varying_focal_relpose(const std::vector<Point2D> &x1, const std::vector<Point2D> &x2,
-                                          ImagePair *image_pair, const BundleOptions &opt = BundleOptions(),
-                                          const std::vector<double> &weights = std::vector<double>());
+BundleStats refine_varying_focal_relpose(const std::vector<Point2D> &x1, const std::vector<Point2D> &x2,
+                                         ImagePair *image_pair, const BundleOptions &opt = BundleOptions(),
+                                         const std::vector<double> &weights = std::vector<double>());
 
 // Relative pose with single unknown focal refinement. Minimizes Reprojection error using monodepth estimates.
 BundleStats refine_monodepth_shared_focal_relpose(const std::vector<Point2D> &x1, const std::vector<Point2D> &x2,

--- a/PoseLib/robust/estimators/relative_pose.cc
+++ b/PoseLib/robust/estimators/relative_pose.cc
@@ -28,6 +28,7 @@
 
 #include "relative_pose.h"
 
+#include "PoseLib/misc/decompositions.h"
 #include "PoseLib/misc/essential.h"
 #include "PoseLib/robust/bundle.h"
 #include "PoseLib/solvers/gen_relpose_5p1pt.h"
@@ -200,6 +201,89 @@ void SharedFocalRelativePoseEstimator::refine_model(ImagePair *image_pair) const
     }
 
     refine_shared_focal_relpose(x1_inlier, x2_inlier, image_pair, bundle_opt);
+}
+
+void VaryingFocalRelativePoseEstimator::generate_models(ImagePairVector *models) {
+    models->clear();
+    sampler.generate_sample(&sample);
+    for (size_t k = 0; k < sample_sz; ++k) {
+        x1s[k] = x1[sample[k]].homogeneous().normalized();
+        x2s[k] = x2[sample[k]].homogeneous().normalized();
+    }
+
+    std::vector<Eigen::Matrix3d> F_models;
+    relpose_7pt(x1s, x2s, &F_models);
+
+    for (const Eigen::Matrix3d &F : F_models) {
+        auto [cam1, cam2] = focals_from_fundamental(F, Eigen::Vector2d::Zero(), Eigen::Vector2d::Zero());
+
+        const double f1 = cam1.focal();
+        const double f2 = cam2.focal();
+
+        if (!std::isfinite(f1) || !std::isfinite(f2) || f1 <= 0.0 || f2 <= 0.0) {
+            continue;
+        }
+
+        // E = K2^T * F * K1, with K = diag(f, f, 1)
+        Eigen::DiagonalMatrix<double, 3> K1(f1, f1, 1.0), K2(f2, f2, 1.0);
+        Eigen::Matrix3d E = K2 * F * K1;
+
+        // Calibrated rays for cheirality check
+        std::vector<Eigen::Vector3d> x1_calib(sample_sz), x2_calib(sample_sz);
+        for (size_t k = 0; k < sample_sz; ++k) {
+            x1_calib[k] = Eigen::Vector3d(x1[sample[k]][0] / f1, x1[sample[k]][1] / f1, 1.0).normalized();
+            x2_calib[k] = Eigen::Vector3d(x2[sample[k]][0] / f2, x2[sample[k]][1] / f2, 1.0).normalized();
+        }
+
+        CameraPoseVector poses;
+        motion_from_essential(E, x1_calib, x2_calib, &poses);
+
+        for (const CameraPose &pose : poses) {
+            models->emplace_back(pose, cam1, cam2);
+        }
+    }
+}
+
+double VaryingFocalRelativePoseEstimator::score_model(const ImagePair &image_pair, size_t *inlier_count) const {
+    Eigen::DiagonalMatrix<double, 3> K1_inv(1.0, 1.0, image_pair.camera1.focal());
+    Eigen::DiagonalMatrix<double, 3> K2_inv(1.0, 1.0, image_pair.camera2.focal());
+    Eigen::Matrix3d E;
+    essential_from_motion(image_pair.pose, &E);
+    Eigen::Matrix3d F = K2_inv * (E * K1_inv);
+
+    return compute_sampson_msac_score(F, x1, x2, opt.max_error * opt.max_error, inlier_count);
+}
+
+void VaryingFocalRelativePoseEstimator::refine_model(ImagePair *image_pair) const {
+    BundleOptions bundle_opt;
+    bundle_opt.loss_type = BundleOptions::LossType::TRUNCATED;
+    bundle_opt.loss_scale = opt.max_error;
+    bundle_opt.max_iterations = 25;
+
+    Eigen::DiagonalMatrix<double, 3> K1_inv(1.0, 1.0, image_pair->camera1.focal());
+    Eigen::DiagonalMatrix<double, 3> K2_inv(1.0, 1.0, image_pair->camera2.focal());
+    Eigen::Matrix3d E;
+    essential_from_motion(image_pair->pose, &E);
+    Eigen::Matrix3d F = K2_inv * (E * K1_inv);
+
+    std::vector<char> inliers;
+    int num_inl = get_inliers(F, x1, x2, 5 * (opt.max_error * opt.max_error), &inliers);
+    std::vector<Eigen::Vector2d> x1_inlier, x2_inlier;
+    x1_inlier.reserve(num_inl);
+    x2_inlier.reserve(num_inl);
+
+    if (num_inl <= 7) {
+        return;
+    }
+
+    for (size_t pt_k = 0; pt_k < x1.size(); ++pt_k) {
+        if (inliers[pt_k]) {
+            x1_inlier.push_back(x1[pt_k]);
+            x2_inlier.push_back(x2[pt_k]);
+        }
+    }
+
+    refine_varying_focal_relpose(x1_inlier, x2_inlier, image_pair, bundle_opt);
 }
 
 void SharedFocalMonodepthPoseEstimator::generate_models(std::vector<MonoDepthImagePair> *models) {

--- a/PoseLib/robust/estimators/relative_pose.h
+++ b/PoseLib/robust/estimators/relative_pose.h
@@ -174,6 +174,35 @@ class SharedFocalRelativePoseEstimator {
     std::vector<size_t> sample;
 };
 
+class VaryingFocalRelativePoseEstimator {
+  public:
+    VaryingFocalRelativePoseEstimator(const RelativePoseOptions &opt, const std::vector<Point2D> &points2D_1,
+                                      const std::vector<Point2D> &points2D_2)
+        : num_data(points2D_1.size()), opt(opt), x1(points2D_1), x2(points2D_2),
+          sampler(num_data, sample_sz, opt.ransac) {
+        x1s.resize(sample_sz);
+        x2s.resize(sample_sz);
+        sample.resize(sample_sz);
+    }
+
+    void generate_models(ImagePairVector *models);
+    double score_model(const ImagePair &image_pair, size_t *inlier_count) const;
+    void refine_model(ImagePair *image_pair) const;
+
+    const size_t sample_sz = 7;
+    const size_t num_data;
+
+  private:
+    const RelativePoseOptions &opt;
+    const std::vector<Point2D> &x1;
+    const std::vector<Point2D> &x2;
+
+    RandomSampler sampler;
+    // pre-allocated vectors for sampling
+    std::vector<Eigen::Vector3d> x1s, x2s;
+    std::vector<size_t> sample;
+};
+
 class SharedFocalMonodepthPoseEstimator {
   public:
     SharedFocalMonodepthPoseEstimator(const MonoDepthRelativePoseOptions &options,

--- a/PoseLib/robust/optim/relative.h
+++ b/PoseLib/robust/optim/relative.h
@@ -597,7 +597,7 @@ template <typename ResidualWeightVector = UniformWeightVector, typename Accumula
 class VaryingFocalRelativePoseRefiner : public RefinerBase<ImagePair, Accumulator> {
   public:
     VaryingFocalRelativePoseRefiner(const std::vector<Point2D> &points2D_1, const std::vector<Point2D> &points2D_2,
-                                   const ResidualWeightVector &w = ResidualWeightVector())
+                                    const ResidualWeightVector &w = ResidualWeightVector())
         : x1(points2D_1), x2(points2D_2), weights(w) {
         this->num_params = 7;
     }
@@ -652,7 +652,6 @@ class VaryingFocalRelativePoseRefiner : public RefinerBase<ImagePair, Accumulato
 
         df1 << 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, E(0, 2), E(1, 2), E(2, 2) * f2;
         df2 << 0.0, 0.0, E(2, 0), 0.0, 0.0, E(2, 1), 0.0, 0.0, E(2, 2) * f1;
-
 
         for (size_t k = 0; k < x1.size(); ++k) {
             double C = x2[k].homogeneous().dot(F * x1[k].homogeneous());

--- a/PoseLib/robust/optim/relative.h
+++ b/PoseLib/robust/optim/relative.h
@@ -591,6 +591,123 @@ class SharedFocalRelativePoseRefiner : public RefinerBase<ImagePair, Accumulator
     Eigen::Matrix<double, 3, 2> tangent_basis;
 };
 
+// Minimize Sampson error with pinhole camera model for relative pose and two unknown focal lenghts different for each
+// camera.
+template <typename ResidualWeightVector = UniformWeightVector, typename Accumulator = NormalAccumulator>
+class VaryingFocalRelativePoseRefiner : public RefinerBase<ImagePair, Accumulator> {
+  public:
+    VaryingFocalRelativePoseRefiner(const std::vector<Point2D> &points2D_1, const std::vector<Point2D> &points2D_2,
+                                   const ResidualWeightVector &w = ResidualWeightVector())
+        : x1(points2D_1), x2(points2D_2), weights(w) {
+        this->num_params = 7;
+    }
+
+    double compute_residual(Accumulator &acc, const ImagePair &image_pair) {
+        Eigen::Matrix3d E, F;
+        essential_from_motion(image_pair.pose, &E);
+        Eigen::DiagonalMatrix<double, 3> K1_inv(1.0, 1.0, image_pair.camera1.focal());
+        Eigen::DiagonalMatrix<double, 3> K2_inv(1.0, 1.0, image_pair.camera2.focal());
+        F = K2_inv * E * K1_inv;
+
+        for (size_t k = 0; k < x1.size(); ++k) {
+            double C = x2[k].homogeneous().dot(F * x1[k].homogeneous());
+            double nJc_sq = (F.block<2, 3>(0, 0) * x1[k].homogeneous()).squaredNorm() +
+                            (F.block<3, 2>(0, 0).transpose() * x2[k].homogeneous()).squaredNorm();
+
+            acc.add_residual(C / std::sqrt(nJc_sq), weights[k]);
+        }
+        return acc.get_residual();
+    }
+
+    void compute_jacobian(Accumulator &acc, const ImagePair &image_pair) {
+        setup_tangent_basis(image_pair.pose.t, tangent_basis);
+
+        Eigen::Matrix3d E, F, R;
+        R = image_pair.pose.R();
+        essential_from_motion(image_pair.pose, &E);
+        double f1 = image_pair.camera1.focal();
+        double f2 = image_pair.camera2.focal();
+        Eigen::DiagonalMatrix<double, 3> K1_inv(1.0, 1.0, f1);
+        Eigen::DiagonalMatrix<double, 3> K2_inv(1.0, 1.0, f2);
+        F = K2_inv * E * K1_inv;
+
+        // Matrices contain the jacobians of E w.r.t. the rotation and translation parameters
+        Eigen::Matrix<double, 9, 3> dR;
+        Eigen::Matrix<double, 9, 2> dt;
+        deriv_essential_wrt_pose(E, R, tangent_basis, dR, dt);
+
+        dR.row(2) *= f2;
+        dR.row(5) *= f2;
+        dR.row(6) *= f1;
+        dR.row(7) *= f1;
+        dR.row(8) *= f2 * f1;
+
+        dt.row(2) *= f2;
+        dt.row(5) *= f2;
+        dt.row(6) *= f1;
+        dt.row(7) *= f1;
+        dt.row(8) *= f2 * f1;
+
+        Eigen::Matrix<double, 9, 1> df1, df2;
+
+        df1 << 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, E(0, 2), E(1, 2), E(2, 2) * f2;
+        df2 << 0.0, 0.0, E(2, 0), 0.0, 0.0, E(2, 1), 0.0, 0.0, E(2, 2) * f1;
+
+
+        for (size_t k = 0; k < x1.size(); ++k) {
+            double C = x2[k].homogeneous().dot(F * x1[k].homogeneous());
+
+            // J_C is the Jacobian of the epipolar constraint w.r.t. the image points
+            Eigen::Vector4d J_C;
+            J_C << F.block<3, 2>(0, 0).transpose() * x2[k].homogeneous(), F.block<2, 3>(0, 0) * x1[k].homogeneous();
+            const double nJ_C = J_C.norm();
+            const double inv_nJ_C = 1.0 / nJ_C;
+            const double r = C * inv_nJ_C;
+
+            // Compute Jacobian of Sampson error w.r.t the fundamental/essential matrix (3x3)
+            Eigen::Matrix<double, 1, 9> dF;
+            dF << x1[k](0) * x2[k](0), x1[k](0) * x2[k](1), x1[k](0), x1[k](1) * x2[k](0), x1[k](1) * x2[k](1),
+                x1[k](1), x2[k](0), x2[k](1), 1.0;
+            const double s = C * inv_nJ_C * inv_nJ_C;
+            dF(0) -= s * (J_C(2) * x1[k](0) + J_C(0) * x2[k](0));
+            dF(1) -= s * (J_C(3) * x1[k](0) + J_C(0) * x2[k](1));
+            dF(2) -= s * (J_C(0));
+            dF(3) -= s * (J_C(2) * x1[k](1) + J_C(1) * x2[k](0));
+            dF(4) -= s * (J_C(3) * x1[k](1) + J_C(1) * x2[k](1));
+            dF(5) -= s * (J_C(1));
+            dF(6) -= s * (J_C(2));
+            dF(7) -= s * (J_C(3));
+            dF *= inv_nJ_C;
+
+            // and then w.r.t. the pose parameters (rotation + tangent basis for translation)
+            Eigen::Matrix<double, 1, 7> J;
+            J.block<1, 3>(0, 0) = dF * dR;
+            J.block<1, 2>(0, 3) = dF * dt;
+            J(0, 5) = dF * df1;
+            J(0, 6) = dF * df2;
+
+            acc.add_jacobian(r, J, weights[k]);
+        }
+    }
+
+    ImagePair step(const Eigen::VectorXd &dp, const ImagePair &image_pair) const {
+        CameraPose new_pose;
+        new_pose.q = quat_step_post(image_pair.pose.q, dp.block<3, 1>(0, 0));
+        new_pose.t = image_pair.pose.t + tangent_basis * dp.block<2, 1>(3, 0);
+
+        Camera new_camera1 = Camera("SIMPLE_PINHOLE", {image_pair.camera1.focal() + dp(5), 0, 0}, -1, -1);
+        Camera new_camera2 = Camera("SIMPLE_PINHOLE", {image_pair.camera2.focal() + dp(6), 0, 0}, -1, -1);
+
+        return ImagePair(new_pose, new_camera1, new_camera2);
+    }
+
+    typedef ImagePair param_t;
+    const std::vector<Point2D> &x1;
+    const std::vector<Point2D> &x2;
+    const ResidualWeightVector &weights;
+    Eigen::Matrix<double, 3, 2> tangent_basis;
+};
+
 } // namespace poselib
 
 #endif

--- a/PoseLib/robust/ransac.cc
+++ b/PoseLib/robust/ransac.cc
@@ -202,6 +202,29 @@ RansacStats ransac_shared_focal_relpose(const std::vector<Point2D> &x1, const st
     return stats;
 }
 
+RansacStats ransac_varying_focal_relpose(const std::vector<Point2D> &x1, const std::vector<Point2D> &x2,
+                                         const RelativePoseOptions &opt, ImagePair *best_model,
+                                         std::vector<char> *best_inliers) {
+    if (!opt.ransac.score_initial_model) {
+        best_model->pose.q << 1.0, 0.0, 0.0, 0.0;
+        best_model->pose.t.setZero();
+        best_model->camera1 = Camera(SimplePinholeCameraModel::model_id, std::vector<double>{1.0, 0.0, 0.0}, -1, -1);
+        best_model->camera2 = best_model->camera1;
+    }
+    VaryingFocalRelativePoseEstimator estimator(opt, x1, x2);
+    RansacStats stats = ransac<VaryingFocalRelativePoseEstimator>(estimator, opt.ransac, best_model);
+
+    Eigen::DiagonalMatrix<double, 3> K1_inv(1.0, 1.0, best_model->camera1.focal());
+    Eigen::DiagonalMatrix<double, 3> K2_inv(1.0, 1.0, best_model->camera2.focal());
+    Eigen::Matrix3d E;
+    essential_from_motion(best_model->pose, &E);
+    Eigen::Matrix3d F = K2_inv * (E * K1_inv);
+
+    get_inliers(F, x1, x2, opt.max_error * opt.max_error, best_inliers);
+
+    return stats;
+}
+
 RansacStats ransac_shared_focal_monodepth_relpose(const std::vector<Point2D> &x1, const std::vector<Point2D> &x2,
                                                   const std::vector<double> &d1, const std::vector<double> &d2,
                                                   const MonoDepthRelativePoseOptions &opt,

--- a/PoseLib/robust/ransac.h
+++ b/PoseLib/robust/ransac.h
@@ -72,6 +72,10 @@ RansacStats ransac_shared_focal_relpose(const std::vector<Point2D> &x1, const st
                                         const RelativePoseOptions &opt, ImagePair *best_model,
                                         std::vector<char> *best_inliers);
 
+RansacStats ransac_varying_focal_relpose(const std::vector<Point2D> &x1, const std::vector<Point2D> &x2,
+                                         const RelativePoseOptions &opt, ImagePair *best_model,
+                                         std::vector<char> *best_inliers);
+
 RansacStats ransac_shared_focal_monodepth_relpose(const std::vector<Point2D> &x1, const std::vector<Point2D> &x2,
                                                   const std::vector<double> &d1, const std::vector<double> &d2,
                                                   const MonoDepthRelativePoseOptions &opt,

--- a/README.md
+++ b/README.md
@@ -23,31 +23,24 @@ It is fairly straight-forward to implement robust estimators for other problems.
 
 In [robust.h](PoseLib/robust.h) we provide interfaces which normalizes the data, calls the RANSAC and runs a post-RANSAC non-linear refinement. It is also possible to directly call the individual components as well (see e.g. [ransac.h](PoseLib/robust/ransac.h), [bundle.h](PoseLib/robust/bundle.h), etc.). The RANSAC is straight-forward implementation of LO-RANSAC which generate hypothesis with minimal solvers and relies on non-linear refinement for refitting.
 
-The robust estimator takes the following options
+The robust estimator takes the following options.
+
+General RANSAC options:
 ```c++
 struct RansacOptions {
     size_t max_iterations = 100000;
     size_t min_iterations = 1000;
     double dyn_num_trials_mult = 3.0;
     double success_prob = 0.9999;
-    double max_reproj_error = 12.0;  // used for 2D-3D matches
-    double max_epipolar_error = 1.0; // used for 2D-2D matches
     unsigned long seed = 0;
     // If we should use PROSAC sampling. Assumes data is sorted
     bool progressive_sampling = false;
     size_t max_prosac_iterations = 100000;
-    // Whether to use real focal length checking for F estimation: https://arxiv.org/abs/2311.16304
-    // Assumes that principal points of both cameras are at origin.
-    bool real_focal_check = false;
     // Whether to treat the input 'best_model' as an initial model and score it before running the main RANSAC loop
     bool score_initial_model = false;
-    // Whether to estimate the shifts in the calibrated relative pose with monodepth.    
-    bool monodepth_estimate_shift = false;
-    // The weight of the Sampson error compared to the reprojection error used by the monodepth estimators, which use hybrid errors for LO.
-    float monodepth_weight_sampson = 1.0;
 };
 ```
-and the non-linear refinement 
+the non-linear refinement:
 ```c++
 struct BundleOptions {
     size_t max_iterations = 100;
@@ -63,6 +56,21 @@ struct BundleOptions {
     bool verbose = false;
 };
 ```
+
+and the estimator specific options which contain the error thresholds and other settings. For more details and additional option structs (like `AbsolutePoseOptions` or `MonoDepthRelativePoseOptions`), see [types.h](PoseLib/types.h). 
+
+For example, `RelativePoseOptions`:
+```c++
+struct RelativePoseOptions {
+    RansacOptions ransac;
+    BundleOptions bundle;
+
+    double max_error = 1.0;      // Inlier threshold (in pixels)
+    bool tangent_sampson = false; // Whether to use tangent Sampson error in LO
+    bool real_focal_check = false; // Whether to use real focal length checking
+};
+```
+
 Note that in [robust.h](PoseLib/robust.h) this is only used for the post-RANSAC refinement. For the relative pose estimators using monocular depth we recommend using `TRUNCATED_CAUCHY`.
 
 In [bundle.h](PoseLib/robust/bundle.h) we provide non-linear refinement for different problems. Mainly minimizing reprojection error and Sampson error as these performed best in our internal evaluations. These are used in the LO-RANSAC to perform non-linear refitting. Most estimators directly minimize the MSAC score (using `loss_type = TRUNCATED` and `loss_scale = threshold`) over all input correspondences. In practice we found that this works quite well and avoids recursive LO where inliers are added in steps.
@@ -89,11 +97,11 @@ Examples of how the robust estimators can be called are
 ```python
 camera = {'model': 'SIMPLE_PINHOLE', 'width': 1200, 'height': 800, 'params': [960, 600, 400]}
 
-pose, info = poselib.estimate_absolute_pose(p2d, p3d, camera, {'max_reproj_error': 16.0}, {})
+pose, info = poselib.estimate_absolute_pose(p2d, p3d, camera, {'max_error': 16.0}, {})
 ```
 or
 ```python
-F, info = poselib.estimate_fundamental(p2d_1, p2d_2, {'max_epipolar_error': 0.75, 'progressive_sampling': True}, {})
+F, info = poselib.estimate_fundamental(p2d_1, p2d_2, {'max_error': 0.75, 'progressive_sampling': True}, {})
 mask_inl = info['inliers']
 
 ```
@@ -102,20 +110,20 @@ The return value `info` is a dict containing information about the robust estima
 
 
 
-Some of the available estimators are listed below, check [pyposelib.cpp](pybind/pyposelib.cc) and [robust.h](PoseLib/robust.h) for more details. The table also shows which error threshold is used in the estimation (`RansacOptions.max_reproj_error` or `RansacOptions.max_epipolar_error`). All thresholds are given in pixels.
+Some of the available estimators are listed below, check [pyposelib.cpp](pybind/pyposelib.cc) and [robust.h](PoseLib/robust.h) for more details. The table also shows which error threshold is used in the estimation (`max_error` or `max_errors`). All thresholds are given in pixels.
 
-| Method | Arguments | (RansacOptions) Threshold |
+| Method | Arguments | Threshold |
 | --- | --- | --- |
-| <sub>`estimate_absolute_pose`</sub> | <sub> `(p2d, p3d, camera, ransac_opt, bundle_opt, initial_pose=None)`</sub> | <sub>`max_reproj_error` </sub> |
-| <sub>`estimate_absolute_pose_pnpl`</sub> | <sub>`(p2d, p3d, l2d_1, l2d_2, l3d_1, l3d_2, camera, ransac_opt, bundle_opt, initial_pose=None)` </sub> | <sub>`max_reproj_error` (points), `max_epipolar_error` (lines) |
-| <sub>`estimate_generalized_absolute_pose` | <sub>`(p2ds, p3ds, camera_ext, cameras, ransac_opt, bundle_opt, initial_pose=None)`</sub> | <sub>`max_reproj_error`</sub> |
-| <sub>`estimate_relative_pose`</sub> | <sub>`(x1, x2, camera1, camera2, ransac_opt, bundle_opt, initial_pose=None)`</sub> | <sub>`max_epipolar_error` </sub>|
-| <sub>`estimate_shared_focal_relative_pose`</sub> | <sub>`(x1, x2, pp, ransac_opt, bundle_opt, initial_image_pair=None)`</sub> | <sub>`max_epipolar_error` </sub>|
-| <sub>`estimate_fundamental`</sub> | <sub>`(x1, x2, ransac_opt, bundle_opt, initial_F=None)`</sub> | <sub>`max_epipolar_error`</sub> |
-| <sub>`estimate_homography`</sub> | <sub>`(x1, x2, ransac_opt, bundle_opt, initial_H=None)`</sub> | <sub>`max_reproj_error`</sub> |
-| <sub>`estimate_monodepth_relative_pose`</sub> | <sub>`(x1, x2, d1, d2, camera1, camera2, ransac_opt, bundle_opt)`</sub> | <sub>`max_epipolar_error, max_reproj_error`</sub> |
-| <sub>`estimate_monodepth_shared_focal_relative_pose`</sub> | <sub>`(x1, x2, d1, d2, ransac_opt, bundle_opt)`</sub> | <sub>`max_epipolar_error, max_reproj_error`</sub> |
-| <sub>`estimate_monodepth_varying_focal_relative_pose`</sub> | <sub>`(x1, x2, d1, d2, ransac_opt, bundle_opt)`</sub> | <sub>`max_epipolar_error, max_reproj_error`</sub> |
+| <sub>`estimate_absolute_pose`</sub> | <sub> `(p2d, p3d, camera, ransac_opt, bundle_opt, initial_pose=None)`</sub> | <sub>`max_error` </sub> |
+| <sub>`estimate_absolute_pose_pnpl`</sub> | <sub>`(p2d, p3d, l2d_1, l2d_2, l3d_1, l3d_2, camera, ransac_opt, bundle_opt, initial_pose=None)` </sub> | <sub>`max_errors[0]` (points), `max_errors[1]` (lines) |
+| <sub>`estimate_generalized_absolute_pose` | <sub>`(p2ds, p3ds, camera_ext, cameras, ransac_opt, bundle_opt, initial_pose=None)`</sub> | <sub>`max_error`</sub> |
+| <sub>`estimate_relative_pose`</sub> | <sub>`(x1, x2, camera1, camera2, ransac_opt, bundle_opt, initial_pose=None)`</sub> | <sub>`max_error` </sub>|
+| <sub>`estimate_shared_focal_relative_pose`</sub> | <sub>`(x1, x2, pp, ransac_opt, bundle_opt, initial_image_pair=None)`</sub> | <sub>`max_error` </sub>|
+| <sub>`estimate_fundamental`</sub> | <sub>`(x1, x2, ransac_opt, bundle_opt, initial_F=None)`</sub> | <sub>`max_error`</sub> |
+| <sub>`estimate_homography`</sub> | <sub>`(x1, x2, ransac_opt, bundle_opt, initial_H=None)`</sub> | <sub>`max_error`</sub> |
+| <sub>`estimate_monodepth_relative_pose`</sub> | <sub>`(x1, x2, d1, d2, camera1, camera2, ransac_opt, bundle_opt)`</sub> | <sub>`max_errors[0]` (reproj), `max_errors[1]` (epipolar)</sub> |
+| <sub>`estimate_monodepth_shared_focal_relative_pose`</sub> | <sub>`(x1, x2, d1, d2, ransac_opt, bundle_opt)`</sub> | <sub>`max_errors[0]` (reproj), `max_errors[1]` (epipolar)</sub> |
+| <sub>`estimate_monodepth_varying_focal_relative_pose`</sub> | <sub>`(x1, x2, d1, d2, ransac_opt, bundle_opt)`</sub> | <sub>`max_errors[0]` (reproj), `max_errors[1]` (epipolar)</sub> |
 
 ### Storing poses and estimated camera parameters
 To handle poses and cameras we provide the following classes: 

--- a/pybind/bindings/estimators/relative_pose.cc
+++ b/pybind/bindings/estimators/relative_pose.cc
@@ -478,12 +478,13 @@ void register_relative_pose(py::module &m) {
 
     m.def("estimate_monodepth_shared_focal_relative_pose", &estimate_monodepth_shared_focal_relative_pose_wrapper,
           py::arg("points2D_1"), py::arg("points2D_2"), py::arg("depth_1"), py::arg("depth_2"),
-          py::arg("opt") = py::dict(),
+          py::arg("pp") = Eigen::Vector2d::Zero(), py::arg("opt") = py::dict(),
           py::arg("initial_image_pair") = py::none(),
           "Relative pose estimation with depth estimates and unknown equal focal lengths with non-linear refinement.");
 
     m.def("estimate_monodepth_varying_focal_relative_pose", &estimate_monodepth_varying_focal_relative_pose_wrapper,
           py::arg("points2D_1"), py::arg("points2D_2"), py::arg("depth_1"), py::arg("depth_2"),
+          py::arg("pp1") = Eigen::Vector2d::Zero(), py::arg("pp2") = Eigen::Vector2d::Zero(),
           py::arg("opt") = py::dict(),
           py::arg("initial_image_pair") = py::none(),
           "Relative pose estimation with depth estimates and unknown different focal lengths with non-linear "

--- a/pybind/bindings/estimators/relative_pose.cc
+++ b/pybind/bindings/estimators/relative_pose.cc
@@ -148,6 +148,35 @@ std::pair<MonoDepthImagePair, py::dict> estimate_monodepth_shared_focal_relative
     return std::make_pair(image_pair, output_dict);
 }
 
+std::pair<ImagePair, py::dict>
+estimate_varying_focal_relative_pose_wrapper(const std::vector<Eigen::Vector2d> &points2D_1,
+                                             const std::vector<Eigen::Vector2d> &points2D_2,
+                                             const Eigen::Vector2d &pp1, const Eigen::Vector2d &pp2,
+                                             const py::dict &opt_dict,
+                                             const std::optional<ImagePair> &initial_image_pair) {
+
+    RelativePoseOptions opt;
+    update_relative_pose_options(opt_dict, opt);
+
+    ImagePair image_pair;
+    if (initial_image_pair.has_value()) {
+        image_pair = initial_image_pair.value();
+        opt.ransac.score_initial_model = true;
+    }
+
+    std::vector<char> inlier_mask;
+
+    py::gil_scoped_release release;
+    RansacStats stats =
+        estimate_varying_focal_relative_pose(points2D_1, points2D_2, pp1, pp2, opt, &image_pair, &inlier_mask);
+    py::gil_scoped_acquire acquire;
+
+    py::dict output_dict;
+    write_to_dict(stats, output_dict);
+    output_dict["inliers"] = convert_inlier_vector(inlier_mask);
+    return std::make_pair(image_pair, output_dict);
+}
+
 std::pair<MonoDepthImagePair, py::dict> estimate_monodepth_varying_focal_relative_pose_wrapper(
     const std::vector<Eigen::Vector2d> &points2D_1, const std::vector<Eigen::Vector2d> &points2D_2,
     const std::vector<double> &depth_1, const std::vector<double> &depth_2, const py::dict &opt_dict,
@@ -443,6 +472,12 @@ void register_relative_pose(py::module &m) {
           py::arg("points2D_2"), py::arg("pp") = Eigen::Vector2d::Zero(), py::arg("opt") = py::dict(),
           py::arg("initial_image_pair") = py::none(),
           "Relative pose estimation with unknown equal focal lengths with non-linear refinement.");
+
+    m.def("estimate_varying_focal_relative_pose", &estimate_varying_focal_relative_pose_wrapper,
+          py::arg("points2D_1"), py::arg("points2D_2"), py::arg("pp1") = Eigen::Vector2d::Zero(),
+          py::arg("pp2") = Eigen::Vector2d::Zero(), py::arg("opt") = py::dict(),
+          py::arg("initial_image_pair") = py::none(),
+          "Relative pose estimation with two different unknown focal lengths with non-linear refinement.");
 
     m.def("estimate_monodepth_shared_focal_relative_pose", &estimate_monodepth_shared_focal_relative_pose_wrapper,
           py::arg("points2D_1"), py::arg("points2D_2"), py::arg("depth_1"), py::arg("depth_2"),

--- a/pybind/bindings/estimators/relative_pose.cc
+++ b/pybind/bindings/estimators/relative_pose.cc
@@ -121,8 +121,8 @@ estimate_shared_focal_relative_pose_wrapper(const std::vector<Eigen::Vector2d> &
 
 std::pair<MonoDepthImagePair, py::dict> estimate_monodepth_shared_focal_relative_pose_wrapper(
     const std::vector<Eigen::Vector2d> &points2D_1, const std::vector<Eigen::Vector2d> &points2D_2,
-    const std::vector<double> &depth_1, const std::vector<double> &depth_2, const py::dict &opt_dict,
-    const std::optional<MonoDepthImagePair> &initial_image_pair) {
+    const std::vector<double> &depth_1, const std::vector<double> &depth_2, const Eigen::Vector2d &pp,
+    const py::dict &opt_dict, const std::optional<MonoDepthImagePair> &initial_image_pair) {
 
     MonoDepthRelativePoseOptions opt;
     update_monodepth_relative_pose_options(opt_dict, opt);
@@ -135,11 +135,9 @@ std::pair<MonoDepthImagePair, py::dict> estimate_monodepth_shared_focal_relative
 
     std::vector<char> inlier_mask;
 
-    std::vector<Image> output;
-
     py::gil_scoped_release release;
-    RansacStats stats = estimate_shared_focal_monodepth_relative_pose(
-        points2D_1, points2D_2, depth_1, depth_2, opt, &image_pair, &inlier_mask);
+    RansacStats stats = estimate_shared_focal_monodepth_relative_pose(points2D_1, points2D_2, depth_1, depth_2, pp, opt,
+                                                                      &image_pair, &inlier_mask);
     py::gil_scoped_acquire acquire;
 
     py::dict output_dict;
@@ -179,7 +177,8 @@ estimate_varying_focal_relative_pose_wrapper(const std::vector<Eigen::Vector2d> 
 
 std::pair<MonoDepthImagePair, py::dict> estimate_monodepth_varying_focal_relative_pose_wrapper(
     const std::vector<Eigen::Vector2d> &points2D_1, const std::vector<Eigen::Vector2d> &points2D_2,
-    const std::vector<double> &depth_1, const std::vector<double> &depth_2, const py::dict &opt_dict,
+    const std::vector<double> &depth_1, const std::vector<double> &depth_2, const Eigen::Vector2d &pp1,
+    const Eigen::Vector2d &pp2, const py::dict &opt_dict,
     const std::optional<MonoDepthImagePair> &initial_image_pair) {
 
     MonoDepthRelativePoseOptions opt;
@@ -193,11 +192,9 @@ std::pair<MonoDepthImagePair, py::dict> estimate_monodepth_varying_focal_relativ
 
     std::vector<char> inlier_mask;
 
-    std::vector<Image> output;
-
     py::gil_scoped_release release;
-    RansacStats stats = estimate_varying_focal_monodepth_relative_pose(
-        points2D_1, points2D_2, depth_1, depth_2, opt, &image_pair, &inlier_mask);
+    RansacStats stats = estimate_varying_focal_monodepth_relative_pose(points2D_1, points2D_2, depth_1, depth_2, pp1,
+                                                                       pp2, opt, &image_pair, &inlier_mask);
     py::gil_scoped_acquire acquire;
 
     py::dict output_dict;

--- a/tests/optim_relative_test.cc
+++ b/tests/optim_relative_test.cc
@@ -238,6 +238,104 @@ bool test_shared_focal_relative_pose_refinement() {
     return true;
 }
 
+bool test_varying_focal_relative_pose_normal_acc() {
+    const size_t N = 10;
+    std::string camera1_str = "0 SIMPLE_PINHOLE 1 1 1.2 0.0 0.0";
+    std::string camera2_str = "0 SIMPLE_PINHOLE 1 1 0.8 0.0 0.0";
+    Camera camera1;
+    camera1.initialize_from_txt(camera1_str);
+    Camera camera2;
+    camera2.initialize_from_txt(camera2_str);
+
+    CameraPose pose;
+    std::vector<Eigen::Vector2d> x1, x2;
+    setup_scene(N, pose, x1, x2, camera1, camera2);
+    ImagePair image_pair = ImagePair(pose, camera1, camera2);
+
+    NormalAccumulator acc;
+    VaryingFocalRelativePoseRefiner refiner(x1, x2);
+    acc.initialize(refiner.num_params);
+
+    // Check that residual is zero
+    acc.reset_residual();
+    refiner.compute_residual(acc, image_pair);
+    double residual = acc.get_residual();
+    REQUIRE_SMALL(residual, 1e-6);
+
+    // Check the gradient is zero
+    acc.reset_jacobian();
+    refiner.compute_jacobian(acc, image_pair);
+    REQUIRE_SMALL(acc.Jtr.norm(), 1e-6);
+
+    return true;
+}
+
+bool test_varying_focal_relative_pose_jacobian() {
+    const size_t N = 10;
+    std::string camera1_str = "0 SIMPLE_PINHOLE 1 1 1.2 0.0 0.0";
+    std::string camera2_str = "0 SIMPLE_PINHOLE 1 1 0.8 0.0 0.0";
+    Camera camera1;
+    camera1.initialize_from_txt(camera1_str);
+    Camera camera2;
+    camera2.initialize_from_txt(camera2_str);
+
+    CameraPose pose;
+    std::vector<Eigen::Vector2d> x1, x2;
+    setup_scene(N, pose, x1, x2, camera1, camera2);
+    ImagePair image_pair = ImagePair(pose, camera1, camera2);
+    VaryingFocalRelativePoseRefiner<UniformWeightVector, TestAccumulator> refiner(x1, x2);
+
+    const double delta = 1e-6;
+    double jac_err = verify_jacobian<decltype(refiner), ImagePair>(refiner, image_pair, delta);
+    REQUIRE_SMALL(jac_err, 1e-6)
+
+    // Test that compute_residual and compute_jacobian are compatible
+    TestAccumulator acc;
+    acc.reset_residual();
+    double r1 = refiner.compute_residual(acc, image_pair);
+    acc.reset_jacobian();
+    refiner.compute_jacobian(acc, image_pair);
+    double r2 = 0.0;
+    for (int i = 0; i < acc.rs.size(); ++i) {
+        r2 += acc.weights[i] * acc.rs[i].squaredNorm();
+    }
+    REQUIRE_SMALL(std::abs(r1 - r2), 1e-10);
+
+    return true;
+}
+//
+bool test_varying_focal_relative_pose_refinement() {
+    const size_t N = 10;
+    std::string camera1_str = "0 SIMPLE_PINHOLE 1 1 1.2 0.0 0.0";
+    std::string camera2_str = "0 SIMPLE_PINHOLE 1 1 0.8 0.0 0.0";
+    Camera camera1;
+    camera1.initialize_from_txt(camera1_str);
+    Camera camera2;
+    camera2.initialize_from_txt(camera2_str);
+
+    CameraPose pose;
+    std::vector<Eigen::Vector2d> x1, x2;
+    setup_scene(N, pose, x1, x2, camera1, camera2);
+    ImagePair image_pair = ImagePair(pose, camera1, camera2);
+
+    // Add some noise
+    test_rng::Rng rng = test_rng::make_rng("varying_focal_relative_pose_refinement_noise");
+    for (int i = 0; i < N; ++i) {
+        x1[i] += 5e-4 * test_rng::symmetric_vec2(rng);
+        x2[i] += 5e-4 * test_rng::symmetric_vec2(rng);
+    }
+
+    VaryingFocalRelativePoseRefiner refiner(x1, x2);
+
+    BundleOptions bundle_opt;
+    bundle_opt.step_tol = 1e-12;
+    BundleStats stats = lm_impl(refiner, &image_pair, bundle_opt, print_iteration);
+    log_bundle_stats(stats, "test_varying_focal_relative_pose_refinement");
+    REQUIRE(check_bundle_cost_and_gradient(stats, 1e-8, "test_varying_focal_relative_pose_refinement"));
+
+    return true;
+}
+
 bool test_tangent_sampson_fix_camera_relative_pose_jacobian() {
     const size_t N = 10;
     std::string camera_str = "3 RADIAL 1936 1296 2425.85 932.38 629.325 -0.04012 0.00123";
@@ -461,6 +559,9 @@ std::vector<Test> register_optim_relative_test() {
             TEST(test_shared_focal_relative_pose_normal_acc),
             TEST(test_shared_focal_relative_pose_jacobian),
             TEST(test_shared_focal_relative_pose_refinement),
+            TEST(test_varying_focal_relative_pose_normal_acc),
+            TEST(test_varying_focal_relative_pose_jacobian),
+            TEST(test_varying_focal_relative_pose_refinement),
             TEST(test_tangent_sampson_fix_camera_relative_pose_jacobian),
             TEST(test_tangent_sampson_fix_camera_relative_pose_refinement),
             TEST(test_tangent_sampson_camera_relative_pose_jacobian),


### PR DESCRIPTION
This PR adds an estimator with a refiner for the case of relative pose with two unknown focal lengths. The estimator uses the 7pt algorithm. Each F is decomposed into focals using the Bougnoux formula. If valid focals are obtained the pose is estimated from E considering the cheirality of inliers. The scoring uses Sampson of F while the refinement optimizes the pose and the focals directly.

In practice this is better than estimating F and decomposing it later as decomposition from a single F is more likely to fail. Still this does not work so well due to the common degeneracies.

Below you can compare the results for posebench (subset = True):
```
Finished running evaluation in 53.3 seconds (22 datasets)
Datasets: fisheye_grossmunster_4342,fisheye_kirchenge_2731,megadepth1500_sift,megadepth1500_spsg,megadepth1500_splg,megadepth1500_roma,megadepth1500_dkm,megadepth1500_aspanformer,scannet1500_sift,scannet1500_spsg,scannet1500_roma,scannet1500_dkm,scannet1500_aspanformer,imc_british_museum,imc_london_bridge,imc_piazza_san_marco,imc_florence_cathedral_side,imc_milan_cathedral,imc_sagrada_familia,imc_lincoln_memorial_statue,imc_mount_rushmore,imc_st_pauls_cathedral

                     AUC5   AUC10   AUC20   avg_rt   med_rt 
E (poselib)         51.89   65.63   76.33   29.6ms   27.9ms 
E (poselib,TS)      51.46   65.26   76.14   90.4ms   76.5ms 
F (poselib)         33.61   47.30   60.42   28.8ms   25.9ms 
F (poselib,decomp)  17.14   27.70   36.47   28.9ms   25.8ms 
F (poselib,vf)      19.54   32.07   44.86   23.8ms   21.5ms 
E (COLMAP)          45.47   61.43   73.90   20.0ms   17.0ms 
F (COLMAP)          31.24   42.84   56.37    7.3ms    5.5ms
```

The `decomp` version estimates F and decomposes it after the final model is provided. The `vf` version is the current PR. I imlemented this in posebench. Will add posebench PR soon.