### PR TITLE
Update cmake eigen to use no_module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ target_compile_features(${build_target} PUBLIC cxx_std_17)
 endfunction()
 
 # Eigen
-find_package(Eigen3 REQUIRED)
+find_package(Eigen3 REQUIRED NO_MODULE)
 
 # Library sources
 add_subdirectory(${LIBRARY_FOLDER})


### PR DESCRIPTION
This updates the find_package for Eigen to use `NO_MODULE` as suggested by the Eigen documentation: https://libeigen.gitlab.io/eigen/docs-nightly/TopicCMakeGuide.html

This improves finding newer versions of eigen.

Without this fix, newer versions of Eigen can give the following error:
```
Could NOT find Eigen3: Found unsuitable version "..", but required is at least "3.1.0" (found /usr/local/include/eigen3)
```