### PR TITLE
Fix state ordering in relpose_kFk_9pt

### DIFF
--- a/PoseLib/solvers/relpose_kFk_9pt.cc
+++ b/PoseLib/solvers/relpose_kFk_9pt.cc
@@ -48,12 +48,12 @@ int relpose_kFk_9pt(const std::vector<Eigen::Vector3d> &x1, const std::vector<Ei
     M = -D1.partialPivLu().solve(D4);
 
     Eigen::MatrixXd D = Eigen::MatrixXd::Zero(6, 6);
-    D(0, 5) = 1.0;
-    D.row(1) = M.row(2);
-    D.row(2) = M.row(5);
-    D.row(3) = M.row(6);
-    D.row(4) = M.row(7);
-    D.row(5) = M.row(8);
+    D.row(0) = M.row(2);
+    D.row(1) = M.row(5);
+    D.row(2) = M.row(6);
+    D.row(3) = M.row(7);
+    D.row(4) = M.row(8);
+    D(5, 4) = 1.0; 
 
     Eigen::EigenSolver<Eigen::MatrixXd> es(D);
     const Eigen::VectorXcd &eigenvalues = es.eigenvalues();

--- a/PoseLib/solvers/relpose_kFk_9pt.cc
+++ b/PoseLib/solvers/relpose_kFk_9pt.cc
@@ -53,7 +53,7 @@ int relpose_kFk_9pt(const std::vector<Eigen::Vector3d> &x1, const std::vector<Ei
     D.row(2) = M.row(6);
     D.row(3) = M.row(7);
     D.row(4) = M.row(8);
-    D(5, 4) = 1.0; 
+    D(5, 4) = 1.0;
 
     Eigen::EigenSolver<Eigen::MatrixXd> es(D);
     const Eigen::VectorXcd &eigenvalues = es.eigenvalues();


### PR DESCRIPTION
This PR fixes the state ordering in the 6x6 eigenvalue matrix used by `relpose_kFk_9pt`.

From the construction of `D4`, the state is

```
g = [lambda*f3, lambda*f6, lambda*f7,
     lambda*f8, lambda*f9, lambda^2*f9]^T
```

With mu = 1/lambda, the corresponding eigenvalue relation requires the rows constructed from `M` to precede the shift relation
`g5 = mu * g6`.

The previous implementation used a cyclically permuted state ordering without applying the corresponding column permutation to `M`.

I found this issue while benchmarking the solver on noiseless synthetic data. With the fix, the ground-truth distortion parameter is recovered as expected.

This was also confirmed by Viktor Kocur and Yaqing Ding.